### PR TITLE
GB borders new default and additions.

### DIFF
--- a/handheld/console-border/dmg-2x.glslp
+++ b/handheld/console-border/dmg-2x.glslp
@@ -31,17 +31,28 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 scale_type5 = source
 scale5 = 1.0
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
 video_scale = "3.0"
 SCALE = "0.6667"
 OUT_X = "1600.0"
 OUT_Y = "800.0"
-adjacent_texel_alpha_blending = "0.18"
-pixel_opacity = "0.90"
-shadow_opacity = "0.90"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
 console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER

--- a/handheld/console-border/dmg-3x.glslp
+++ b/handheld/console-border/dmg-3x.glslp
@@ -31,15 +31,26 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
 video_scale = "3.0"
 SCALE = "1.0"
 OUT_X = "2400.0"
 OUT_Y = "1200.0"
-adjacent_texel_alpha_blending = "0.15"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
 console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER

--- a/handheld/console-border/dmg-4x.glslp
+++ b/handheld/console-border/dmg-4x.glslp
@@ -31,15 +31,26 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
 video_scale = "4.0"
 SCALE = "1.0"
 OUT_X = "3200.0"
 OUT_Y = "1600.0"
-adjacent_texel_alpha_blending = "0.14"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
 console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER

--- a/handheld/console-border/dmg-5x.glslp
+++ b/handheld/console-border/dmg-5x.glslp
@@ -31,15 +31,26 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
 video_scale = "4.0"
 SCALE = "1.25"
 OUT_X = "4000.0"
 OUT_Y = "2000.0"
-adjacent_texel_alpha_blending = "0.14"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
 console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER

--- a/handheld/console-border/dmg-6x.glslp
+++ b/handheld/console-border/dmg-6x.glslp
@@ -31,15 +31,26 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
 video_scale = "4.0"
 SCALE = "1.5"
 OUT_X = "4800.0"
 OUT_Y = "2400.0"
-adjacent_texel_alpha_blending = "0.14"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
 console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER

--- a/handheld/console-border/gb-pocket-2x.glslp
+++ b/handheld/console-border/gb-pocket-2x.glslp
@@ -31,18 +31,30 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 scale_type5 = source
 scale5 = 1.0
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
 video_scale = "3.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
+screen_offset_x = "0.0"
+screen_offset_y = "0.0"
 SCALE = "0.6667"
 OUT_X = "1600.0"
 OUT_Y = "800.0"
-adjacent_texel_alpha_blending = "0.18"
-pixel_opacity = "0.90"
-shadow_opacity = "0.90"
-console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER
 COLOR_PALETTE = resources/pocket-palette.png

--- a/handheld/console-border/gb-pocket-3x.glslp
+++ b/handheld/console-border/gb-pocket-3x.glslp
@@ -31,16 +31,28 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
 video_scale = "3.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
+screen_offset_x = "0.0"
+screen_offset_y = "0.0"
 SCALE = "1.0"
 OUT_X = "2400.0"
 OUT_Y = "1200.0"
-adjacent_texel_alpha_blending = "0.15"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
-console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER
 COLOR_PALETTE = resources/pocket-palette.png

--- a/handheld/console-border/gb-pocket-4x.glslp
+++ b/handheld/console-border/gb-pocket-4x.glslp
@@ -31,16 +31,28 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
 video_scale = "4.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
+screen_offset_x = "0.0"
+screen_offset_y = "0.0"
 SCALE = "1.0"
 OUT_X = "3200.0"
 OUT_Y = "1600.0"
-adjacent_texel_alpha_blending = "0.14"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
-console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER
 COLOR_PALETTE = resources/pocket-palette.png

--- a/handheld/console-border/gb-pocket-5x.glslp
+++ b/handheld/console-border/gb-pocket-5x.glslp
@@ -31,16 +31,28 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
 video_scale = "4.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
+screen_offset_x = "0.0"
+screen_offset_y = "0.0"
 SCALE = "1.25"
 OUT_X = "4000.0"
 OUT_Y = "2000.0"
-adjacent_texel_alpha_blending = "0.14"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
-console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER
 COLOR_PALETTE = resources/pocket-palette.png

--- a/handheld/console-border/gb-pocket-6x.glslp
+++ b/handheld/console-border/gb-pocket-6x.glslp
@@ -31,16 +31,28 @@ scale4 = 1.0
 alias4 = "PASS4"
 
 shader5 = shader-files/gb-pass-5.glsl
+filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;adjacent_texel_alpha_blending;pixel_opacity;shadow_opacity;console_border_enable"
+parameters = "baseline_alpha;grey_balance;response_time;console_border_enable;video_scale;blending_mode;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;bg_smoothing;shadow_opacity;shadow_offset_x;shadow_offset_y;screen_offset_x;screen_offset_y;SCALE;OUT_X;OUT_Y"
+baseline_alpha = "0.03"
+response_time = "0.333"
+grey_balance = "3.5"
+console_border_enable = "1.0"
 video_scale = "4.0"
+blending_mode = "0.0"
+adjacent_texel_alpha_blending = "0.38"
+contrast = "0.8"
+screen_light = "0.9"
+pixel_opacity = "0.95"
+bg_smoothing = "0.0"
+shadow_opacity = "0.55"
+shadow_offset_x = "-1.5"
+shadow_offset_y = "1.5"
+screen_offset_x = "0.0"
+screen_offset_y = "0.0"
 SCALE = "1.5"
 OUT_X = "4800.0"
 OUT_Y = "2400.0"
-adjacent_texel_alpha_blending = "0.14"
-pixel_opacity = "0.80"
-shadow_opacity = "0.80"
-console_border_enable = "1.0"
 
 textures = COLOR_PALETTE;BACKGROUND;BORDER
 COLOR_PALETTE = resources/pocket-palette.png

--- a/handheld/shaders/gameboy/shader-files/gb-pass0.glsl
+++ b/handheld/shaders/gameboy/shader-files/gb-pass0.glsl
@@ -27,6 +27,9 @@
 // Does not affect the border region of the screen - [0, 1]
 #pragma parameter baseline_alpha "Baseline Alpha" 0.10 0.0 1.0 0.01
 
+// Fine-tune the balance between the different shades of grey
+#pragma parameter grey_balance "Grey Balance" 3.0 2.0 4.0 0.1
+
 // Simulate response time
 // Higher values result in longer color transition periods - [0, 1]
 #pragma parameter response_time "LCD Response Time" 0.333 0.0 0.777 0.111
@@ -76,11 +79,13 @@ uniform COMPAT_PRECISION vec2 InputSize;
 
 #ifdef PARAMETER_UNIFORM
 uniform COMPAT_PRECISION float baseline_alpha;
+uniform COMPAT_PRECISION float grey_balance;
 uniform COMPAT_PRECISION float response_time;
 uniform COMPAT_PRECISION float console_border_enable;
 uniform COMPAT_PRECISION float video_scale;
 #else
 #define baseline_alpha 0.10
+#define grey_balance 3.0
 #define response_time 0.333
 #define console_border_enable 0.0
 #define video_scale 3.0
@@ -169,6 +174,7 @@ COMPAT_VARYING vec2 one_texel;
 
 #ifdef PARAMETER_UNIFORM
 uniform COMPAT_PRECISION float baseline_alpha;
+uniform COMPAT_PRECISION float grey_balance;
 uniform COMPAT_PRECISION float response_time;
 uniform COMPAT_PRECISION float console_border_enable;
 uniform COMPAT_PRECISION float video_scale;
@@ -210,7 +216,7 @@ void main()
     input_rgb += (prev5_rgb - input_rgb) * pow(response_time, 6.0);
     input_rgb += (prev6_rgb - input_rgb) * pow(response_time, 7.0);
 
-    float rgb_to_alpha = (input_rgb.r + input_rgb.g + input_rgb.b) * 0.333333333
+    float rgb_to_alpha = (input_rgb.r + input_rgb.g + input_rgb.b) / grey_balance
                         + (is_on_dot * baseline_alpha);
 
     // Apply foreground color and assign alpha value


### PR DESCRIPTION
Glsl version of those shaders looked really strange.
The shadow_opacity parameter different behaviour was the main cause.
I added a missing grey_balance parameter while keeping the default value unchanged.
Tweaked all values to get close to the cg version.
Added linear filter on pass5, fix some scaling artefacts.

DMG [old](http://postimg.org/image/g22urxadn/) / [new](http://postimg.org/image/xteh6dpsb/)
Pocket [old](http://postimg.org/image/dnaz7hu4r/) / [new](http://postimg.org/image/nync05lu3/)