### PR TITLE
(LUT) Clamp to highest possible value

### DIFF
--- a/reshade/shaders/LUT/LUT.glsl
+++ b/reshade/shaders/LUT/LUT.glsl
@@ -104,7 +104,7 @@ void main()
 	float green = ( imgColor.g * (LUT_Size - 1.0) + 0.4999 ) / LUT_Size;
 	float blue1 = (floor( imgColor.b  * (LUT_Size - 1.0) ) / LUT_Size) + red;
 	float blue2 = (ceil( imgColor.b  * (LUT_Size - 1.0) ) / LUT_Size) + red;
-	float mixer = clamp(max((imgColor.b - blue1) / (blue2 - blue1), 0.0), 0.0, 1.0);
+	float mixer = clamp(max((imgColor.b - blue1) / (blue2 - blue1), 0.0), 0.0, 32.0);
 	vec4 color1 = texture( SamplerLUT, vec2( blue1, green ));
 	vec4 color2 = texture( SamplerLUT, vec2( blue2, green ));
 	FragColor = mixfix(color1, color2, mixer);//mix(color1, color2, mixer);


### PR DESCRIPTION
Fixes a slight regression with the output of the blue channel by clamping mixer to 32.0, which seems to be the highest possible value that it can have.