### PR TITLE
add precision medium int

### DIFF
--- a/blurs/blur11fast-horizontal.glsl
+++ b/blurs/blur11fast-horizontal.glsl
@@ -2055,6 +2055,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/blurs/blur11fast-vertical.glsl
+++ b/blurs/blur11fast-vertical.glsl
@@ -2054,6 +2054,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/blurs/blur5fast-horizontal.glsl
+++ b/blurs/blur5fast-horizontal.glsl
@@ -2055,6 +2055,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/blurs/blur5fast-vertical.glsl
+++ b/blurs/blur5fast-vertical.glsl
@@ -2054,6 +2054,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/blurs/blur9fast-horizontal.glsl
+++ b/blurs/blur9fast-horizontal.glsl
@@ -2055,6 +2055,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/blurs/blur9fast-vertical.glsl
+++ b/blurs/blur9fast-vertical.glsl
@@ -2054,6 +2054,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/borders/resources/shiny-iterations.glsl
+++ b/borders/resources/shiny-iterations.glsl
@@ -120,6 +120,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/borders/resources/voronoi.glsl
+++ b/borders/resources/voronoi.glsl
@@ -114,6 +114,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-easymode.glsl
+++ b/crt/shaders/crt-easymode.glsl
@@ -102,6 +102,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-bloom-approx.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-bloom-approx.glsl
@@ -4064,6 +4064,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-bloom-horizontal-reconstitute.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-bloom-horizontal-reconstitute.glsl
@@ -4550,6 +4550,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-bloom-vertical.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-bloom-vertical.glsl
@@ -3478,6 +3478,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-brightpass.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-brightpass.glsl
@@ -4705,6 +4705,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-first-pass-linearize-crt-gamma-bob-fields.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-first-pass-linearize-crt-gamma-bob-fields.glsl
@@ -2305,6 +2305,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-geometry-aa-last-pass-passthru.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-geometry-aa-last-pass-passthru.glsl
@@ -1293,6 +1293,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-geometry-aa-last-pass.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-geometry-aa-last-pass.glsl
@@ -3440,6 +3440,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-mask-resize-horizontal.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-mask-resize-horizontal.glsl
@@ -2957,6 +2957,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-mask-resize-vertical.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-mask-resize-vertical.glsl
@@ -2957,6 +2957,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-scanlines-horizontal-apply-mask.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-scanlines-horizontal-apply-mask.glsl
@@ -4750,6 +4750,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/crt-royale/src/crt-royale-scanlines-vertical-interlacing.glsl
+++ b/crt/shaders/crt-royale/src/crt-royale-scanlines-vertical-interlacing.glsl
@@ -2320,6 +2320,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/gtu-famicom/DAC.glsl
+++ b/crt/shaders/gtu-famicom/DAC.glsl
@@ -111,6 +111,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/gtu-famicom/DAC_combined.glsl
+++ b/crt/shaders/gtu-famicom/DAC_combined.glsl
@@ -67,6 +67,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/metacrt/Image.glsl
+++ b/crt/shaders/metacrt/Image.glsl
@@ -67,6 +67,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/metacrt/bufC.glsl
+++ b/crt/shaders/metacrt/bufC.glsl
@@ -66,6 +66,7 @@ void main()
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/crt/shaders/metacrt/bufD.glsl
+++ b/crt/shaders/metacrt/bufD.glsl
@@ -64,6 +64,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/denoisers/shaders/slow-bilateral.glsl
+++ b/denoisers/shaders/slow-bilateral.glsl
@@ -63,6 +63,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/dithering/shaders/bayer-matrix-dithering.glsl
+++ b/dithering/shaders/bayer-matrix-dithering.glsl
@@ -65,6 +65,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/eagle/shaders/supereagle.glsl
+++ b/eagle/shaders/supereagle.glsl
@@ -92,6 +92,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/hqx/shader-files/hq2x-halphon.glsl
+++ b/hqx/shader-files/hq2x-halphon.glsl
@@ -83,6 +83,7 @@ void main()
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/misc/edge-detect.glsl
+++ b/misc/edge-detect.glsl
@@ -62,6 +62,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/misc/nes-color-decoder.glsl
+++ b/misc/nes-color-decoder.glsl
@@ -76,6 +76,7 @@ void main()
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/ntsc/shaders/artifact-colors/artifact-colors1.glsl
+++ b/ntsc/shaders/artifact-colors/artifact-colors1.glsl
@@ -72,6 +72,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/ntsc/shaders/artifact-colors/artifact-colors2.glsl
+++ b/ntsc/shaders/artifact-colors/artifact-colors2.glsl
@@ -73,6 +73,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/omniscale/shaders/omniscale-legacy.glsl
+++ b/omniscale/shaders/omniscale-legacy.glsl
@@ -86,6 +86,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/omniscale/shaders/omniscale.glsl
+++ b/omniscale/shaders/omniscale.glsl
@@ -88,6 +88,7 @@ out mediump vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/procedural/mudlord-emeraldenvy4.glsl
+++ b/procedural/mudlord-emeraldenvy4.glsl
@@ -76,6 +76,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else

--- a/sabr/shaders/sabr-hybrid.glsl
+++ b/sabr/shaders/sabr-hybrid.glsl
@@ -105,6 +105,7 @@ out vec4 FragColor;
 precision highp float;
 #else
 precision mediump float;
+precision mediump int;
 #endif
 #define COMPAT_PRECISION mediump
 #else


### PR DESCRIPTION
VC4 open source GLES driver needs precision mediump int to compile these
shaders without precision error.

https://github.com/libretro/glsl-shaders/pull/29#issuecomment-327880857