### PR TITLE
(simpletex_lcd) Update colour correction values

### DIFF
--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color-4k.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color-4k.glsl
@@ -183,14 +183,14 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.84
+#define CC_R 0.86
 #define CC_G 0.66
 #define CC_B 0.81
 #define CC_RG 0.11
-#define CC_RB 0.13
+#define CC_RB 0.1325
 #define CC_GR 0.19
-#define CC_GB 0.06
-#define CC_BR -0.03
+#define CC_GB 0.0575
+#define CC_BR -0.05
 #define CC_BG 0.23
 
 void main()

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color.glsl
@@ -183,14 +183,14 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.84
+#define CC_R 0.86
 #define CC_G 0.66
 #define CC_B 0.81
 #define CC_RG 0.11
-#define CC_RB 0.13
+#define CC_RB 0.1325
 #define CC_GR 0.19
-#define CC_GB 0.06
-#define CC_BR -0.03
+#define CC_GB 0.0575
+#define CC_BR -0.05
 #define CC_BG 0.23
 
 void main()

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.glsl
@@ -183,15 +183,15 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86629
-#define CC_G 0.70857
-#define CC_B 0.77215
-#define CC_RG 0.02429
-#define CC_RB 0.11337
-#define CC_GR 0.13361
-#define CC_GB 0.11448
-#define CC_BR 0.0
-#define CC_BG 0.26714
+#define CC_R 0.87
+#define CC_G 0.66
+#define CC_B 0.79
+#define CC_RG 0.115
+#define CC_RB 0.14
+#define CC_GR 0.18
+#define CC_GB 0.07
+#define CC_BR -0.05
+#define CC_BG 0.225
 
 void main()
 {

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.glsl
@@ -183,15 +183,15 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86629
-#define CC_G 0.70857
-#define CC_B 0.77215
-#define CC_RG 0.02429
-#define CC_RB 0.11337
-#define CC_GR 0.13361
-#define CC_GB 0.11448
-#define CC_BR 0.0
-#define CC_BG 0.26714
+#define CC_R 0.87
+#define CC_G 0.66
+#define CC_B 0.79
+#define CC_RG 0.115
+#define CC_RB 0.14
+#define CC_GR 0.18
+#define CC_GB 0.07
+#define CC_BR -0.05
+#define CC_BG 0.225
 
 void main()
 {


### PR DESCRIPTION
This PR just updates the `simpletex_lcd` shaders with Pokefan531's latest colour correction values (https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/174)

@hunterk I notice that the standard base colour correction shaders (`gba-color.glsl`, `gbc-color.glsl`, etc.) are very much out of date at this point - shall I update these as well...?