### PR TITLE
replace invalid scale_type_<number> with scale_type<number>

### DIFF
--- a/anti-aliasing/aa-shader-4.0-level2.glslp
+++ b/anti-aliasing/aa-shader-4.0-level2.glslp
@@ -12,4 +12,4 @@ scale1 = 2.0
 
 shader2 = ../sharpen/shaders/adaptive-sharpen.glsl
 filter_linear2 = false
-scale_type_2 = source
+scale_type2 = source

--- a/anti-aliasing/advanced-aa.glslp
+++ b/anti-aliasing/advanced-aa.glslp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.glsl
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/borders/sgb/sgb-gbc-color-tvout+interlacing.glslp
+++ b/borders/sgb/sgb-gbc-color-tvout+interlacing.glslp
@@ -7,7 +7,7 @@ shader4 = ../../misc/interlacing.glsl
 shader5 = ../../auto-box/box-center.glsl
 
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0
 
 scale_type_x1 = absolute

--- a/borders/sgb/sgb-gbc-color.glslp
+++ b/borders/sgb/sgb-gbc-color.glslp
@@ -3,7 +3,7 @@ shader0 = "../../handheld/shaders/color/gbc-color.glsl"
 shader1 = "../resources/imgborder-sgb.glsl"
 
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0
 
 scale_type_x1 = "absolute"

--- a/crt/crt-caligari.glslp
+++ b/crt/crt-caligari.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-caligari.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-cgwg-fast.glslp
+++ b/crt/crt-cgwg-fast.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-cgwg-fast.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-easymode.glslp
+++ b/crt/crt-easymode.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-easymode.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-geom.glslp
+++ b/crt/crt-geom.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-geom.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-hyllian-3d.glslp
+++ b/crt/crt-hyllian-3d.glslp
@@ -3,4 +3,4 @@ shaders = 1
 shader0 = shaders/crt-hyllian-3d.glsl
 filter_linear0 = true
 srgb_framebuffer0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-hyllian-multipass.glslp
+++ b/crt/crt-hyllian-multipass.glslp
@@ -11,4 +11,4 @@ scale_y0 = 1.0
 shader1 = shaders/crt-hyllian-multipass/crt-hyllian-pass1.glsl
 filter_linear1 = false
 srgb_framebuffer1 = false
-scale_type_1 = source
+scale_type1 = source

--- a/crt/crt-hyllian.glslp
+++ b/crt/crt-hyllian.glslp
@@ -3,4 +3,4 @@ shaders = 1
 shader0 = shaders/crt-hyllian.glsl
 filter_linear0 = false
 srgb_framebuffer0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-lottes.glslp
+++ b/crt/crt-lottes.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-lottes.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/ddt/ddt.glslp
+++ b/ddt/ddt.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/ddt.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/denoisers/fast-bilateral.glslp
+++ b/denoisers/fast-bilateral.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/fast-bilateral.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/dithering/bayer-matrix-dithering.glslp
+++ b/dithering/bayer-matrix-dithering.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bayer-matrix-dithering.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/dithering/gendither.glslp
+++ b/dithering/gendither.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/gendither.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/eagle/super-eagle.glslp
+++ b/eagle/super-eagle.glslp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.glsl
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/handheld/dot.glslp
+++ b/handheld/dot.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/dot.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/handheld/gba-color.glslp
+++ b/handheld/gba-color.glslp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/gba-color.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/handheld/gbc-color.glslp
+++ b/handheld/gbc-color.glslp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/gbc-color.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/handheld/gbc-gambatte-color.glslp
+++ b/handheld/gbc-gambatte-color.glslp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/gbc-gambatte-color.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/handheld/lcd-grid-v2.glslp
+++ b/handheld/lcd-grid-v2.glslp
@@ -2,7 +2,7 @@ shaders = 1
 
 shader0 = shaders/lcd-cgwg/lcd-grid-v2.glsl
 filter_linear0 = false
-scale_type_0 = viewport
+scale_type0 = viewport
 scale0 = 1.0
 
 parameters = "RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"

--- a/handheld/lcd-grid.glslp
+++ b/handheld/lcd-grid.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lcd-cgwg/lcd-grid.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/handheld/nds-color.glslp
+++ b/handheld/nds-color.glslp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/nds-color.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/handheld/palm-color.glslp
+++ b/handheld/palm-color.glslp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/palm-color.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/handheld/psp-color.glslp
+++ b/handheld/psp-color.glslp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/psp-color.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/handheld/vba-color.glslp
+++ b/handheld/vba-color.glslp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/vba-color.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/motionblur/braid-rewind.glslp
+++ b/motionblur/braid-rewind.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/braid-rewind.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/motionblur/mix_frames.glslp
+++ b/motionblur/mix_frames.glslp
@@ -3,4 +3,4 @@ shaders = "1"
 shader0 = "shaders/mix_frames.glsl"
 
 filter_linear0 = "false"
-scale_type_0 = "source"
+scale_type0 = "source"

--- a/motionblur/mix_frames_smart.glslp
+++ b/motionblur/mix_frames_smart.glslp
@@ -3,4 +3,4 @@ shaders = "1"
 shader0 = "shaders/mix_frames_smart.glsl"
 
 filter_linear0 = "false"
-scale_type_0 = "source"
+scale_type0 = "source"

--- a/motionblur/motionblur-simple.glslp
+++ b/motionblur/motionblur-simple.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/motionblur-simple.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/motionblur/response-time.glslp
+++ b/motionblur/response-time.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/response-time.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/nedi/fast-bilateral-nedi.glslp
+++ b/nedi/fast-bilateral-nedi.glslp
@@ -1,7 +1,7 @@
 shaders = "5"
 shader0 = ../denoisers/shaders/fast-bilateral.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 shader1 = "shaders/nedi-pass0.glsl"
 filter_linear1 = false
 wrap_mode1 = "clamp_to_border"

--- a/nes_raw_palette/gtu-famicom.glslp
+++ b/nes_raw_palette/gtu-famicom.glslp
@@ -10,14 +10,14 @@ frame_count_mod0 = 2
 float_framebuffer0 = true
 
 shader1 = shaders/gtu-famicom/lowPass.glsl
-scale_type_1 = source
+scale_type1 = source
 scale_1 = 1.0
 filter_linear1 = false
 frame_count_mod1 = 32
 float_framebuffer1 = true
 
 shader2 = shaders/gtu-famicom/combFilter.glsl
-scale_type_2 = source
+scale_type2 = source
 scale_2 = 1.0
 filter_linear2 = false
 frame_count_mod2 = 2

--- a/presets/tvout+interlacing/gtu-famicom-240p+interlacing.glslp
+++ b/presets/tvout+interlacing/gtu-famicom-240p+interlacing.glslp
@@ -10,14 +10,14 @@ filter_linear0 = false
 frame_count_mod0 = 2
 
 shader1 = ../../nes_raw_palette/shaders/gtu-famicom/lowPass.glsl
-scale_type_1 = source
+scale_type1 = source
 scale_1 = 1.0
 float_framebuffer1 = true
 filter_linear1 = false
 frame_count_mod1 = 32
 
 shader2 = ../../nes_raw_palette/shaders/gtu-famicom/combFilter.glsl
-scale_type_2 = source
+scale_type2 = source
 scale_2 = 1.0
 float_framebuffer2 = true
 filter_linear2 = false

--- a/presets/tvout/gtu-famicom-240p.glslp
+++ b/presets/tvout/gtu-famicom-240p.glslp
@@ -10,14 +10,14 @@ filter_linear0 = false
 frame_count_mod0 = 2
 
 shader1 = ../../nes_raw_palette/shaders/gtu-famicom/lowPass.glsl
-scale_type_1 = source
+scale_type1 = source
 scale_1 = 1.0
 float_framebuffer1 = true
 filter_linear1 = false
 frame_count_mod1 = 32
 
 shader2 = ../../nes_raw_palette/shaders/gtu-famicom/combFilter.glsl
-scale_type_2 = source
+scale_type2 = source
 scale_2 = 1.0
 float_framebuffer2 = true
 filter_linear2 = false

--- a/retro/retro-v2.glslp
+++ b/retro/retro-v2.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/retro-v2.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/sabr/sabr.glslp
+++ b/sabr/sabr.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/sabr-v3.0.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/scalehq/2xScaleHQ.glslp
+++ b/scalehq/2xScaleHQ.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = "shaders/2xScaleHQ.glsl"
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/scalehq/4xScaleHQ.glslp
+++ b/scalehq/4xScaleHQ.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = "shaders/4xScaleHQ.glsl"
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/scalenx/scale2x.glslp
+++ b/scalenx/scale2x.glslp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.glsl
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale2xSFX.glslp
+++ b/scalenx/scale2xSFX.glslp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.glsl
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale2xplus.glslp
+++ b/scalenx/scale2xplus.glslp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.glsl
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale3x.glslp
+++ b/scalenx/scale3x.glslp
@@ -8,4 +8,4 @@ scale_y0 = 3.0
 
 shader1 = ../stock.glsl
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/sharpen/adaptive-sharpen-multipass.glslp
+++ b/sharpen/adaptive-sharpen-multipass.glslp
@@ -2,7 +2,7 @@ shaders = 2
 
 shader0 = shaders/adaptive-sharpen-pass1.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 shader1 = shaders/adaptive-sharpen-pass2.glsl
 filter_linear1 = false
-scale_type_1 = source
+scale_type1 = source

--- a/windowed/jinc2-sharp.glslp
+++ b/windowed/jinc2-sharp.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/jinc2-sharp.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/jinc2-sharper.glslp
+++ b/windowed/jinc2-sharper.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/jinc2-sharper.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/jinc2.glslp
+++ b/windowed/jinc2.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/jinc2.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/lanczos2-sharp.glslp
+++ b/windowed/lanczos2-sharp.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lanczos2-sharp.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/2xBR-lv1-multipass.glslp
+++ b/xbr/2xBR-lv1-multipass.glslp
@@ -2,8 +2,8 @@ shaders = 2
 
 shader0 = "shaders/2xBR-multipass/2xbr-lv1-c-pass0.glsl"
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 
 shader1 = "shaders/2xBR-multipass/2xbr-lv1-c-pass1.glsl"
 filter_linear1 = false
-scale_type_1 = source
+scale_type1 = source

--- a/xbr/xbr-lv2-noblend.glslp
+++ b/xbr/xbr-lv2-noblend.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv2-noblend.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv2.glslp
+++ b/xbr/xbr-lv2.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv2.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv3-multipass.glslp
+++ b/xbr/xbr-lv3-multipass.glslp
@@ -2,8 +2,8 @@ shaders = 2
 
 shader0 = "shaders/xbr-lv3-multipass/xbr-lv3-pass0.glsl"
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 
 shader1 = "shaders/xbr-lv3-multipass/xbr-lv3-pass1.glsl"
 filter_linear1 = false
-scale_type_1 = source
+scale_type1 = source

--- a/xbr/xbr-lv3.glslp
+++ b/xbr/xbr-lv3.glslp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv3.glsl
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xsal/2xsal.glslp
+++ b/xsal/2xsal.glslp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.glsl
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/xsoft/4xsoft.glslp
+++ b/xsoft/4xsoft.glslp
@@ -14,4 +14,4 @@ scale_y1 = 2.0
 
 shader2 = ../stock.glsl
 filter_linear2 = true
-scale_type_2 = source
+scale_type2 = source

--- a/xsoft/4xsoftSdB.glslp
+++ b/xsoft/4xsoftSdB.glslp
@@ -14,4 +14,4 @@ scale_y1 = 2.0
 
 shader2 = ../stock.glsl
 filter_linear2 = true
-scale_type_2 = source
+scale_type2 = source


### PR DESCRIPTION
Fixing the presets has no further effect, since most presets try to use the default value of `source`.
Only lcd-grid-v2 tries to use `viewport`, but since it's for the last shader in the chain, there is again no effect.