### PR TITLE
Fixed errors in reshade/shaders/bloom

### DIFF
--- a/reshade/shaders/bloom/BloomPass0.glsl
+++ b/reshade/shaders/bloom/BloomPass0.glsl
@@ -187,12 +187,12 @@ void main()
    vec4 tempbloom = vec4(0.);
    vec2 bloomuv = vec2(0.);
 
-   const vec2 offset[4] = {
+   const vec2 offset[4] = vec2[4](
       vec2(1.0, 1.0),
       vec2(1.0, 1.0),
       vec2(-1.0, 1.0),
       vec2(-1.0, -1.0)
-   };
+   );
 
    for (int i = 0; i < 4; i++)
    {

--- a/reshade/shaders/bloom/BloomPass1.glsl
+++ b/reshade/shaders/bloom/BloomPass1.glsl
@@ -102,7 +102,7 @@ void main()
 {
    vec4 bloom = vec4(0.0);
 
-   const vec2 offset[8] = {
+   const vec2 offset[8] = vec2[8](
       vec2(1.0, 1.0),
       vec2(0.0, -1.0),
       vec2(-1.0, 1.0),
@@ -111,7 +111,7 @@ void main()
       vec2(0.0, -1.0),
       vec2(1.0, 0.0),
       vec2(-1.0, 0.0)
-   };
+   );
 
    for (int i = 0; i < 8; i++)
    {

--- a/reshade/shaders/bloom/BloomPass2.glsl
+++ b/reshade/shaders/bloom/BloomPass2.glsl
@@ -102,7 +102,7 @@ void main()
 {
    vec4 bloom = vec4(0.0);
 
-   const vec2 offset[8] = {
+   const vec2 offset[8] = vec2[8](
       vec2(0.707, 0.707),
       vec2(0.707, -0.707),
       vec2(-0.707, 0.707),
@@ -111,7 +111,7 @@ void main()
       vec2(0.0, -1.0),
       vec2(1.0, 0.0),
       vec2(-1.0, 0.0)
-   };
+   );
 
    for (int i = 0; i < 8; i++)
    {

--- a/reshade/shaders/bloom/BloomPass3.glsl
+++ b/reshade/shaders/bloom/BloomPass3.glsl
@@ -103,7 +103,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
    vec4 sum = vec4(0.);
    vec2 axis = isBlurVert ? vec2(0., 1.) : vec2(1., 0.);
 
-   const float weight[11] = {
+   const float weight[11] = float[11](
       0.082607,
       0.080977,
       0.076276,
@@ -115,7 +115,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
       0.023066,
       0.016436,
       0.011254
-   };
+   );
 
    for (int i = -10; i < 11; i++)
    {

--- a/reshade/shaders/bloom/BloomPass4.glsl
+++ b/reshade/shaders/bloom/BloomPass4.glsl
@@ -103,7 +103,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
    vec4 sum = vec4(0.);
    vec2 axis = isBlurVert ? vec2(0., 1.) : vec2(1., 0.);
 
-   const float weight[11] = {
+   const float weight[11] = float[11](
       0.082607,
       0.080977,
       0.076276,
@@ -115,7 +115,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
       0.023066,
       0.016436,
       0.011254
-   };
+   );
 
    for (int i = -10; i < 11; i++)
    {

--- a/reshade/shaders/bloom/LensFlarePass0.glsl
+++ b/reshade/shaders/bloom/LensFlarePass0.glsl
@@ -155,7 +155,7 @@ vec3 GetDistortedTex(sampler2D tex, vec2 sample_center, vec2 sample_vector, vec3
 vec3 GetBrightPass(vec2 coords)
 {
    vec3 c = COMPAT_TEXTURE(BackBuffer, coords).rgb;
-   vec3 bC = max(c - fFlareLuminance.xxx, 0.0);
+   vec3 bC = max(c - vec3(fFlareLuminance, fFlareLuminance, fFlareLuminance), 0.0);
    float bright = dot(bC, vec3(1.0));
    bright = smoothstep(0.0, 0.5, bright);
    vec3 result = mix(vec3(0.0), c, vec3(bright));
@@ -183,7 +183,7 @@ void main()
    // Lenz
    if (bLenzEnable)
    {
-      const vec3 lfoffset[19] = {
+      const vec3 lfoffset[19] = vec3[19](
          vec3(0.9, 0.01, 4),
          vec3(0.7, 0.25, 25),
          vec3(0.3, 0.25, 15),
@@ -203,8 +203,8 @@ void main()
          vec3(20, 0.5, 0),
          vec3(0.4, 1, 10),
          vec3(0.00001, 10, 20)
-      };
-      const vec3 lffactors[19] = {
+      );
+      const vec3 lffactors[19] = vec3[19](
          vec3(1.5, 1.5, 0),
          vec3(0, 1.5, 0),
          vec3(0, 0, 1.5),
@@ -224,7 +224,7 @@ void main()
          vec3(1, 1, 0),
          vec3(0, 0, 0.2),
          vec3(0.012,0.313,0.588)
-      };
+      );
 
       vec2 lfcoord = vec2(0.);
       vec3 lenstemp = vec3(0.);
@@ -308,7 +308,7 @@ void main()
    if (bAnamFlareEnable)
    {
       vec3 anamFlare = vec3(0.);
-      const float gaussweight[5] = { 0.2270270270, 0.1945945946, 0.1216216216, 0.0540540541, 0.0162162162 };
+      const float gaussweight[5] = float[5](0.2270270270, 0.1945945946, 0.1216216216, 0.0540540541, 0.0162162162);
 
       for (int z = -4; z < 5; z++)
       {

--- a/reshade/shaders/bloom/LensFlarePass1.glsl
+++ b/reshade/shaders/bloom/LensFlarePass1.glsl
@@ -129,7 +129,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
    vec4 sum = vec4(0.);
    vec2 axis = isBlurVert ? vec2(0., 1.) : vec2(1., 0.);
 
-   const float weight[11] = {
+   const float weight[11] = float[11](
       0.082607,
       0.080977,
       0.076276,
@@ -141,7 +141,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
       0.023066,
       0.016436,
       0.011254
-   };
+   );
 
    for (int i = -10; i < 11; i++)
    {

--- a/reshade/shaders/bloom/LensFlarePass2.glsl
+++ b/reshade/shaders/bloom/LensFlarePass2.glsl
@@ -129,7 +129,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
    vec4 sum = vec4(0.);
    vec2 axis = isBlurVert ? vec2(0., 1.) : vec2(1., 0.);
 
-   const float weight[11] = {
+   const float weight[11] = float[11](
       0.082607,
       0.080977,
       0.076276,
@@ -141,7 +141,7 @@ vec4 GaussBlur22(vec2 coord, sampler2D tex, float mult, float lodlevel, bool isB
       0.023066,
       0.016436,
       0.011254
-   };
+   );
 
    for (int i = -10; i < 11; i++)
    {


### PR DESCRIPTION
I got compiler errors with the #version (s) defined in each .glsl file. Those errors can go with #version 420. I chose to make them compatible with older versions instead.
Replaced some C style initializers and some swizzles on scalars with more compatible constructors.