### PR TITLE
Fix compiler errors

### DIFF
--- a/procedural/dila-frickinlasers.glsl
+++ b/procedural/dila-frickinlasers.glsl
@@ -225,9 +225,9 @@ float tracel(vec3 o, vec3 r)
 
 vec3 _texture(vec3 p)
 {
-	vec3 ta = texture(iChannel0, vec2(p.y,p.z)).xyz;
-    vec3 tb = texture(iChannel0, vec2(p.x,p.z)).xyz;
-    vec3 tc = texture(iChannel0, vec2(p.x,p.y)).xyz;
+	vec3 ta = texture(Texture, vec2(p.y,p.z)).xyz;
+    vec3 tb = texture(Texture, vec2(p.x,p.z)).xyz;
+    vec3 tc = texture(Texture, vec2(p.x,p.y)).xyz;
     return (ta + tb + tc) / 3.0;
 }
 

--- a/procedural/iq-input-time.glsl
+++ b/procedural/iq-input-time.glsl
@@ -137,10 +137,10 @@ vec3 hash3( float n ) { return fract(sin(vec3(n,n+1.0,n+2.0))*43758.5453123); }
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
     // get time
-    float mils = fract(iDate.w);
-	float secs = mod( floor(iDate.w),        60.0 );
-	float mins = mod( floor(iDate.w/60.0),   60.0 );
-	float hors = mod( floor(iDate.w/3600.0), 24.0 );
+    float mils = fract(iGlobalTime);
+	float secs = mod( floor(iGlobalTime),        60.0 );
+	float mins = mod( floor(iGlobalTime/60.0),   60.0 );
+	float hors = mod( floor(iGlobalTime/3600.0), 24.0 );
     
     // enable this for subsecond resolution
     //secs += mils;

--- a/procedural/iq-input-time.glsl
+++ b/procedural/iq-input-time.glsl
@@ -102,7 +102,6 @@ COMPAT_VARYING vec4 TEX0;
 #define OutSize vec4(OutputSize, 1.0 / OutputSize)
 
 // delete all 'params.' or 'registers.' or whatever in the fragment
-//float iGlobalTime = float(FrameCount)*0.016666666666666666;
 float iGlobalTime = float(FrameCount)* 1.0 / FPS;
 vec2 iResolution = OutputSize.xy;
 

--- a/procedural/iq-input-time.glsl
+++ b/procedural/iq-input-time.glsl
@@ -7,11 +7,14 @@
 
 // Parameter lines go here:
 #pragma parameter RETRO_PIXEL_SIZE "Retro Pixel Size" 0.84 0.0 1.0 0.01
+#pragma parameter FPS "Display Refresh Rate (Hz)" 60.0 50.0 240.0 1.0
 #ifdef PARAMETER_UNIFORM
 // All parameter floats need to have COMPAT_PRECISION in front of them
 uniform COMPAT_PRECISION float RETRO_PIXEL_SIZE;
+uniform COMPAT_PRECISION float FPS;
 #else
 #define RETRO_PIXEL_SIZE 0.84
+#define FPS 60.0
 #endif
 
 #if defined(VERTEX)
@@ -99,7 +102,8 @@ COMPAT_VARYING vec4 TEX0;
 #define OutSize vec4(OutputSize, 1.0 / OutputSize)
 
 // delete all 'params.' or 'registers.' or whatever in the fragment
-float iGlobalTime = float(FrameCount)*0.025;
+//float iGlobalTime = float(FrameCount)*0.016666666666666666;
+float iGlobalTime = float(FrameCount)* 1.0 / FPS;
 vec2 iResolution = OutputSize.xy;
 
 // Created by inigo quilez - iq/2013


### PR DESCRIPTION
Fixed compiler errors on two shaders.
Added a pragma parameter to procedural/iq-input-time.glsl for setting the refresh rate of the display so the time can be calculated more accurately (it used a fixed value that made it run too fast).