### PR TITLE
Create crt-guest-dr-venom-stock.glslp

### DIFF
--- a/crt/crt-guest-dr-venom-stock.glslp
+++ b/crt/crt-guest-dr-venom-stock.glslp
@@ -1,0 +1,75 @@
+shaders = 12
+
+shader0 = ../stock.glsl
+filter_linear0 = false
+scale_type_x0 = source
+scale_type_y0 = absolute
+scale_y0 = 240
+
+shader1 = shaders/guest/lut/lut.glsl
+filter_linear1 = false
+scale_type1 = source
+scale1 = 1.0
+
+textures = "SamplerLUT1;SamplerLUT2;SamplerLUT3"
+SamplerLUT1 = shaders/guest/lut/sony_trinitron1.png
+SamplerLUT1_linear = true 
+SamplerLUT2 = shaders/guest/lut/sony_trinitron2.png
+SamplerLUT2_linear = true 
+SamplerLUT3 = shaders/guest/lut/other1.png
+SamplerLUT3_linear = true 
+
+shader2 = shaders/guest/color-profiles.glsl
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = shaders/guest/d65-d50.glsl
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+
+shader4 = ../stock.glsl
+filter_linear4 = false
+scale_type4 = source
+scale4 = 1.0
+
+shader5 = ../stock.glsl
+filter_linear5 = false
+scale_type5 = source
+scale5 = 1.0
+
+shader6 = ../stock.glsl
+filter_linear6 = false
+scale_type6 = source
+scale6 = 1.0
+
+shader7 = shaders/guest/linearize.glsl
+filter_linear7 = false
+scale_type7 = source
+scale7 = 1.0
+float_framebuffer7 = true
+
+shader8 = shaders/guest/blur_horiz.glsl
+filter_linear8 = false
+scale_type8 = source
+scale8 = 1.0
+float_framebuffer8 = true
+
+shader9 = shaders/guest/blur_vert.glsl
+filter_linear9 = false
+scale_type9 = source
+scale9 = 1.0
+float_framebuffer9 = true
+
+shader10 = shaders/guest/linearize_scanlines.glsl
+filter_linear10 = true
+scale_type10 = source
+scale10 = 1.0
+float_framebuffer10 = true
+
+shader11 = shaders/guest/crt-guest-dr-venom.glsl
+filter_linear11 = true
+scale_type11 = viewport
+scale_x11 = 1.0
+scale_y11 = 1.0


### PR DESCRIPTION
A stock version of crt-guest-dr-venom shader for systems like N64, GameCube, Playstation, Saturn, Dreamcast etc.