### PR TITLE
fixed #114 - vhs shader on n.switch

### DIFF
--- a/vhs/shaders/vhs.glsl
+++ b/vhs/shaders/vhs.glsl
@@ -14,8 +14,8 @@
 #define COMPAT_ATTRIBUTE in
 #define COMPAT_TEXTURE texture
 #else
-#define COMPAT_VARYING varying 
-#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
 #define COMPAT_TEXTURE texture2D
 #endif
 
@@ -31,7 +31,7 @@ COMPAT_ATTRIBUTE vec4 TexCoord;
 COMPAT_VARYING vec4 COL0;
 COMPAT_VARYING vec4 TEX0;
 
-vec4 _oPosition1; 
+vec4 _oPosition1;
 uniform mat4 MVPMatrix;
 uniform COMPAT_PRECISION int FrameDirection;
 uniform COMPAT_PRECISION int FrameCount;
@@ -101,7 +101,7 @@ uniform COMPAT_PRECISION float smear;
 #define iChannel0 Texture
 
 //YIQ/RGB shit
-vec3 rgb2yiq(vec3 c){   
+vec3 rgb2yiq(vec3 c){
 					return vec3(
 						(0.2989*c.x + 0.5959*c.y + 0.2115*c.z),
 						(0.5870*c.x - 0.2744*c.y - 0.5229*c.z),
@@ -109,15 +109,15 @@ vec3 rgb2yiq(vec3 c){
 					);
 				}
 
-vec3 yiq2rgb(vec3 c){				
+vec3 yiq2rgb(vec3 c){
 					return vec3(
 						(	 1.0*c.x +	  1.0*c.y + 	1.0*c.z),
 						( 0.956*c.x - 0.2720*c.y - 1.1060*c.z),
 						(0.6210*c.x - 0.6474*c.y + 1.7046*c.z)
 					);
 				}
-        
-vec2 Circle(float Start, float Points, float Point) 
+
+vec2 Circle(float Start, float Points, float Point)
 {
 	float Rad = (3.141592 * 2.0 * (1.0 / Points)) * (Point + Start);
 	//return vec2(sin(Rad), cos(Rad));
@@ -130,10 +130,10 @@ vec3 Blur(vec2 uv, float d){
     float b = 1.0;
     t=0.0;
     vec2 PixelOffset=vec2(d+.0005*t,0);
-    
+
     float Start = 2.0 / 14.0;
     vec2 Scale = 0.66 * 4.0 * 2.0 * PixelOffset.xy;
-    
+
     vec3 N0 = COMPAT_TEXTURE(iChannel0, uv + Circle(Start, 14.0, 0.0) * Scale).rgb;
     vec3 N1 = COMPAT_TEXTURE(iChannel0, uv + Circle(Start, 14.0, 1.0) * Scale).rgb;
     vec3 N2 = COMPAT_TEXTURE(iChannel0, uv + Circle(Start, 14.0, 2.0) * Scale).rgb;
@@ -149,11 +149,11 @@ vec3 Blur(vec2 uv, float d){
     vec3 N12 = COMPAT_TEXTURE(iChannel0, uv + Circle(Start, 14.0, 12.0) * Scale).rgb;
     vec3 N13 = COMPAT_TEXTURE(iChannel0, uv + Circle(Start, 14.0, 13.0) * Scale).rgb;
     vec3 N14 = COMPAT_TEXTURE(iChannel0, uv).rgb;
-    
+
 	vec4 clr = COMPAT_TEXTURE(iChannel0, uv);
     float W = 1.0 / 15.0;
-    
-    clr.rgb= 
+
+    clr.rgb=
 		(N0 * W) +
 		(N1 * W) +
 		(N2 * W) +
@@ -182,7 +182,7 @@ vec2 jumpy(vec2 uv, float framecount)
 	vec2 look = uv;
 	float window = 1./(1.+80.*(look.y-mod(framecount/4.,1.))*(look.y-mod(framecount/4.,1.)));
 	look.x += 0.05 * sin(look.y*10. + framecount)/20.*onOff(4.,4.,.3, framecount)*(0.5+cos(framecount*20.))*window;
-	float vShift = (0.1*wiggle) * 0.4*onOff(2.,3.,.9, framecount)*(sin(framecount)*sin(framecount*20.) + 
+	float vShift = (0.1*wiggle) * 0.4*onOff(2.,3.,.9, framecount)*(sin(framecount)*sin(framecount*20.) +
 										 (0.5 + 0.1*sin(framecount*200.)*cos(framecount)));
 	look.y = mod(look.y - 0.01 * vShift, 1.);
 	return look;
@@ -190,41 +190,41 @@ vec2 jumpy(vec2 uv, float framecount)
 
 void main()
 {
-   float timer = (float(FrameDirection) > 0.5) ? float(FrameCount) : 0.0;
-	float d=.1-round(mod(iTime/3.0,1.0))*.1;
+    float timer = (float(FrameDirection) > 0.5) ? float(FrameCount) : 0.0;
+	float d = 0.1 - ceil(mod(iTime/3.0,1.0) + 0.5) * 0.1;
 	vec2 uv = jumpy(vTexCoord.xy, iTime);
 	vec2 uv2 = uv;
 
     float s = 0.0001 * -d + 0.0001 * wiggle * sin(iTime);
-   
+
 	float e = min(.30,pow(max(0.0,cos(uv.y*4.0+.3)-.75)*(s+0.5)*1.0,3.0))*25.0;
     float r = (iTime*(2.0*s));
     uv.x+=abs(r*pow(min(.003,(-uv.y+(.01*mod(iTime, 17.0))))*3.0,2.0));
-    
+
     d=.051+abs(sin(s/4.0));
     float c = max(0.0001,.002*d) * smear;
 	vec2 uvo = uv;
     vec4 final;
 	final.xyz =Blur(uv,c+c*(uv.x));
     float y = rgb2yiq(final.xyz).r;
-    
+
 	uv.x+=.01*d;
     c*=6.0;
     final.xyz =Blur(uv,c);
     float i = rgb2yiq(final.xyz).g;
-    
+
     uv.x+=.005*d;
-    
+
     c*=2.50;
     final.xyz =Blur(uv,c);
     float q = rgb2yiq(final.xyz).b;
 	final = vec4(yiq2rgb(vec3(y,i,q))-pow(s+e*2.0,3.0), 1.0);
-	
+
 	vec4 play_osd = COMPAT_TEXTURE(play, uv2 * TextureSize.xy / InputSize.xy);
 	float show_overlay = (mod(timer, 100.0) < 50.0) && (timer != 0.0) && (timer < 500.0) ? play_osd.a : 0.0;
 	show_overlay = clamp(show_overlay, 0.0, 1.0);
 	final = mix(final, play_osd, show_overlay);
 
     FragColor = final;
-} 
+}
 #endif


### PR DESCRIPTION
This pull request is focused on a single file/issue fix.

The issue #114 is caused by the function `round` which is currently not supported in whatever GLES implementation the Nintendo Switch is using with libnx / nouveau implementation. 

I've tested the use of the `floor(x + 0.5)` and `ceil(x + 0.5)` and in Windows, both seem to function equally. However, floor causes flickering on the Nintendo Switch, whilst ceil works as intended.

Some lines have been cleared of trailing white space by my text editor, there's no functional difference.

Thanks for checking out this PR!