### PR TITLE
Update GBA/GBC/NDS colour correction parameters

### DIFF
--- a/handheld/shaders/color/gba-color.glsl
+++ b/handheld/shaders/color/gba-color.glsl
@@ -14,31 +14,31 @@
 #endif
 
 // Parameter lines go here:
-#pragma parameter darken_screen "Darken Screen" 0.5 -0.25 1.5 0.05
+#pragma parameter darken_screen "Darken Screen" 1.0 -0.25 1.0 0.05
 #ifdef PARAMETER_UNIFORM
 // All parameter floats need to have COMPAT_PRECISION in front of them
 uniform COMPAT_PRECISION float darken_screen;
 #else
-#define darken_screen 0.5
+#define darken_screen 1.0
 #endif
 
 #define target_gamma 2.2
 #define display_gamma 2.2
 #define sat 1.0
-#define lum 1.0
+#define lum 0.94
 #define contrast 1.0
 #define blr 0.0
 #define blg 0.0
 #define blb 0.0
-#define r 0.86
-#define g 0.66
-#define b 0.81
-#define rg 0.11
-#define rb 0.1325
-#define gr 0.19
-#define gb 0.0575
-#define br -0.05
-#define bg 0.23
+#define r 0.82
+#define g 0.665
+#define b 0.73
+#define rg 0.125
+#define rb 0.195
+#define gr 0.24
+#define gb 0.075
+#define br -0.06
+#define bg 0.21
 #define overscan_percent_x 0.0
 #define overscan_percent_y 0.0
 

--- a/handheld/shaders/color/nds-color.glsl
+++ b/handheld/shaders/color/nds-color.glsl
@@ -13,23 +13,23 @@
 #define COMPAT_PRECISION
 #endif
 
-#define target_gamma 2.2
-#define display_gamma 2.2
+#define target_gamma 1.91
+#define display_gamma 1.91
 #define sat 1.0
-#define lum 1.0
+#define lum 0.89
 #define contrast 1.0
 #define blr 0.0
 #define blg 0.0
 #define blb 0.0
-#define r 0.85
-#define g 0.655
-#define b 0.865
-#define rg 0.095
-#define rb 0.06
-#define gr 0.20
-#define gb 0.075
-#define br -0.05
-#define bg 0.25
+#define r 0.87
+#define g 0.645
+#define b 0.73
+#define rg 0.10
+#define rb 0.10
+#define gr 0.255
+#define gb 0.17
+#define br -0.125
+#define bg 0.255
 #define overscan_percent_x 0.0
 #define overscan_percent_y 0.0
 

--- a/handheld/shaders/lcd1x_nds.glsl
+++ b/handheld/shaders/lcd1x_nds.glsl
@@ -115,17 +115,18 @@ uniform COMPAT_PRECISION float BRIGHTEN_LCD;
 
 #define NDS_SCREEN_HEIGHT 192.0
 
-#define TARGET_GAMMA 2.2
-const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.85
-#define CC_G 0.655
-#define CC_B 0.865
-#define CC_RG 0.095
-#define CC_RB 0.06
-#define CC_GR 0.20
-#define CC_GB 0.075
-#define CC_BR -0.05
-#define CC_BG 0.25
+#define TARGET_GAMMA 1.91
+const float INV_DISPLAY_GAMMA = 1.0 / 1.91;
+#define CC_LUM 0.89
+#define CC_R 0.87
+#define CC_G 0.645
+#define CC_B 0.73
+#define CC_RG 0.10
+#define CC_RB 0.10
+#define CC_GR 0.255
+#define CC_GB 0.17
+#define CC_BR -0.125
+#define CC_BG 0.255
 
 /*
    FRAGMENT SHADER
@@ -149,7 +150,7 @@ void main()
    colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA));
    colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
                      CC_GR, CC_G,  CC_GB,
-                     CC_BR, CC_BG, CC_B) * colour.rgb;
+                     CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
    colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 
    // Apply LCD grid effect

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color-4k.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color-4k.glsl
@@ -183,15 +183,16 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86
-#define CC_G 0.66
-#define CC_B 0.81
-#define CC_RG 0.11
-#define CC_RB 0.1325
-#define CC_GR 0.19
-#define CC_GB 0.0575
-#define CC_BR -0.05
-#define CC_BG 0.23
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 void main()
 {
@@ -203,10 +204,10 @@ void main()
 	COMPAT_PRECISION vec3 colour = COMPAT_TEXTURE(Texture, InvTextureSize.xy * imgCenterCoord.xy).rgb;
 	
 	// Darken colours (if required...) and apply colour correction
-	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 0.5 + DARKEN_COLOUR));
+	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 1.0 + DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color.glsl
@@ -183,15 +183,16 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86
-#define CC_G 0.66
-#define CC_B 0.81
-#define CC_RG 0.11
-#define CC_RB 0.1325
-#define CC_GR 0.19
-#define CC_GB 0.0575
-#define CC_BR -0.05
-#define CC_BG 0.23
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 void main()
 {
@@ -203,10 +204,10 @@ void main()
 	COMPAT_PRECISION vec3 colour = COMPAT_TEXTURE(Texture, InvTextureSize.xy * imgCenterCoord.xy).rgb;
 	
 	// Darken colours (if required...) and apply colour correction
-	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 0.5 + DARKEN_COLOUR));
+	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 1.0 + DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.glsl
@@ -183,15 +183,16 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.87
-#define CC_G 0.66
-#define CC_B 0.79
-#define CC_RG 0.115
-#define CC_RB 0.14
-#define CC_GR 0.18
-#define CC_GB 0.07
-#define CC_BR -0.05
-#define CC_BG 0.225
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 void main()
 {
@@ -206,7 +207,7 @@ void main()
 	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA - 0.5 + DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.glsl
@@ -183,15 +183,16 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.87
-#define CC_G 0.66
-#define CC_B 0.79
-#define CC_RG 0.115
-#define CC_RB 0.14
-#define CC_GR 0.18
-#define CC_GB 0.07
-#define CC_BR -0.05
-#define CC_BG 0.225
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 void main()
 {
@@ -206,7 +207,7 @@ void main()
 	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA - 0.5 + DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gba-color.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gba-color.glsl
@@ -182,15 +182,16 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86
-#define CC_G 0.66
-#define CC_B 0.81
-#define CC_RG 0.11
-#define CC_RB 0.1325
-#define CC_GR 0.19
-#define CC_GB 0.0575
-#define CC_BR -0.05
-#define CC_BG 0.23
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 void main()
 {
@@ -202,10 +203,10 @@ void main()
 	COMPAT_PRECISION vec3 colour = COMPAT_TEXTURE(Texture, InvTextureSize.xy * imgCenterCoord.xy).rgb;
 	
 	// Darken colours (if required...) and apply colour correction
-	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 0.5 + DARKEN_COLOUR));
+	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 1.0 + DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gbc-color.glsl
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gbc-color.glsl
@@ -182,15 +182,16 @@ const COMPAT_PRECISION float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const COMPAT_PRECISION float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.87
-#define CC_G 0.66
-#define CC_B 0.79
-#define CC_RG 0.115
-#define CC_RB 0.14
-#define CC_GR 0.18
-#define CC_GB 0.07
-#define CC_BR -0.05
-#define CC_BG 0.225
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 void main()
 {
@@ -205,7 +206,7 @@ void main()
 	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA - 0.5 + DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/presets/retro-v2+gba-color.glslp
+++ b/presets/retro-v2+gba-color.glslp
@@ -10,5 +10,5 @@ scale0 = "1.000000"
 filter_linear1 = "false"
 
 parameters = "darken_screen;RETRO_PIXEL_SIZE"
-darken_screen = "0.500000"
+darken_screen = "1.000000"
 RETRO_PIXEL_SIZE = "0.840000"


### PR DESCRIPTION
This PR updates Pokefan531's GBA/GBC/NDS colour correction shaders to the latest version: https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/190

It also updates all derived shaders/presets (i.e. the colour-correction versions of lcd1x, simpletex_lcd, etc.)