### PR TITLE
Fixed missing path to stereoscopic sbs shader

### DIFF
--- a/stereoscopic-3d/side-by-side.glslp
+++ b/stereoscopic-3d/side-by-side.glslp
@@ -1,6 +1,6 @@
 shaders = 1
 
-shader0 = side-by-side-simple.glsl
+shader0 = shaders/side-by-side-simple.glsl
 
 parameters = "eye_sep;y_loc;ana_zoom"
 eye_sep = "0.30"


### PR DESCRIPTION
I found that the shader initially appeared broken to me until I saw that the directory path was incorrect.

~~Default parameters weren't right for my device at all, but I don't know retroarch and shaders well enough to know what's possible atm. I would hope though that better defaults could be created as well that are more dynamic..~~