### PR TITLE
Added 2 additional presets for SBS on mobile devices

### DIFF
--- a/stereoscopic-3d/sbs-flat-mobile-16x9.glslp
+++ b/stereoscopic-3d/sbs-flat-mobile-16x9.glslp
@@ -1,0 +1,11 @@
+shaders = 1
+
+shader0 = shaders/side-by-side-simple.glsl
+
+parameters = "eye_sep;y_loc;BOTH;ana_zoom;warpY;warpX"
+eye_sep = "0.125"
+y_loc = "0.10"
+BOTH = "0.255"
+ana_zoom = "0.66"
+warpY = "0"
+warpX = "0"

--- a/stereoscopic-3d/sbs-warp-mobile-16x9.glslp
+++ b/stereoscopic-3d/sbs-warp-mobile-16x9.glslp
@@ -1,0 +1,11 @@
+shaders = 1
+
+shader0 = shaders/side-by-side-simple.glsl
+
+parameters = "eye_sep;y_loc;BOTH;ana_zoom;warpY;warpX"
+eye_sep = "0.125"
+y_loc = "0.10"
+BOTH = "0.255"
+ana_zoom = "0.66"
+warpY = "0.1"
+warpX = "0.1"

--- a/stereoscopic-3d/side-by-side.glslp
+++ b/stereoscopic-3d/side-by-side.glslp
@@ -1,6 +1,6 @@
 shaders = 1
 
-shader0 = side-by-side-simple.glsl
+shader0 = shaders/side-by-side-simple.glsl
 
 parameters = "eye_sep;y_loc;ana_zoom"
 eye_sep = "0.30"


### PR DESCRIPTION
Original Side by side presets was not adequate for mobile devices in general. This one should work on devices ranging from the iPhone SE 1, 2 (1334x750) and Samsung Galaxy Note 4 WQHD (2560x1440). I suspect any mobile resolution will work with this preset.

Filenames of the presets also mention 16x9 in hopes that people will recognize that they will need to change their core's aspect ratio to 16x9 for proper rendering with VR headsets.