### PR TITLE
fix zfast_crt for rotated games

### DIFF
--- a/crt/shaders/zfast_crt.glsl
+++ b/crt/shaders/zfast_crt.glsl
@@ -178,10 +178,10 @@ void main()
 	COMPAT_PRECISION float YY = Y*Y;
 	
 #if defined(FINEMASK) 
-	COMPAT_PRECISION float whichmask = fract( gl_FragCoord.x*-0.4999);
+	COMPAT_PRECISION float whichmask = fract(floor(vTexCoord.x*OutputSize.x*-0.4999));
 	COMPAT_PRECISION float mask = 1.0 + float(whichmask < 0.5) * -MASK_DARK;
 #else
-	COMPAT_PRECISION float whichmask = fract(gl_FragCoord.x * -0.3333);
+	COMPAT_PRECISION float whichmask = fract(floor(vTexCoord.x*OutputSize.x)*-0.3333);
 	COMPAT_PRECISION float mask = 1.0 + float(whichmask <= 0.33333) * -MASK_DARK;
 #endif
 	COMPAT_PRECISION vec3 colour = COMPAT_TEXTURE(Source, p).rgb;


### PR DESCRIPTION
Follow-up of https://github.com/libretro/RetroArch/pull/12816