### PR TITLE
Fixed reshade LUT in some edge cases (fixes Phantasy Star in Genesis Plus GX)

### DIFF
--- a/reshade/shaders/LUT/LUT.glsl
+++ b/reshade/shaders/LUT/LUT.glsl
@@ -103,7 +103,7 @@ void main()
 	float red = ( imgColor.r * (LUT_Size - 1.0) + 0.4999 ) / (LUT_Size * LUT_Size);
 	float green = ( imgColor.g * (LUT_Size - 1.0) + 0.4999 ) / LUT_Size;
 	float blue1 = (floor( imgColor.b  * (LUT_Size - 1.0) ) / LUT_Size) + red;
-	float blue2 = (ceil( imgColor.b  * (LUT_Size - 1.0) ) / LUT_Size) + red;
+	float blue2 = (ceil( imgColor.b + 0.000001 * (LUT_Size - 1.0) ) / LUT_Size) + red;
 	float mixer = clamp(max((imgColor.b - blue1) / (blue2 - blue1), 0.0), 0.0, 32.0);
 	vec4 color1 = COMPAT_TEXTURE( SamplerLUT, vec2( blue1, green ));
 	vec4 color2 = COMPAT_TEXTURE( SamplerLUT, vec2( blue2, green ));

--- a/reshade/shaders/LUT/multiLUT.glsl
+++ b/reshade/shaders/LUT/multiLUT.glsl
@@ -116,7 +116,7 @@ void main()
 		red = ( imgColor.r * (LUT_Size1 - 1.0) + 0.4999 ) / (LUT_Size1 * LUT_Size1);
 		green = ( imgColor.g * (LUT_Size1 - 1.0) + 0.4999 ) / LUT_Size1;
 		blue1 = (floor( imgColor.b  * (LUT_Size1 - 1.0) ) / LUT_Size1) + red;
-		blue2 = (ceil( imgColor.b  * (LUT_Size1 - 1.0) ) / LUT_Size1) + red;
+		blue2 = (ceil( imgColor.b  + 0.000001 * (LUT_Size1 - 1.0) ) / LUT_Size1) + red;
 		mixer = clamp(max((imgColor.b - blue1) / (blue2 - blue1), 0.0), 0.0, 32.0);
 		color1 = COMPAT_TEXTURE( SamplerLUT1, vec2( blue1, green ));
 		color2 = COMPAT_TEXTURE( SamplerLUT1, vec2( blue2, green ));
@@ -126,7 +126,7 @@ void main()
 		red = ( imgColor.r * (LUT_Size2 - 1.0) + 0.4999 ) / (LUT_Size2 * LUT_Size2);
 		green = ( imgColor.g * (LUT_Size2 - 1.0) + 0.4999 ) / LUT_Size2;
 		blue1 = (floor( imgColor.b  * (LUT_Size2 - 1.0) ) / LUT_Size2) + red;
-		blue2 = (ceil( imgColor.b  * (LUT_Size2 - 1.0) ) / LUT_Size2) + red;
+		blue2 = (ceil( imgColor.b  + 0.000001 * (LUT_Size2 - 1.0) ) / LUT_Size2) + red;
 		mixer = clamp(max((imgColor.b - blue1) / (blue2 - blue1), 0.0), 0.0, 32.0);
 		color1 = COMPAT_TEXTURE( SamplerLUT2, vec2( blue1, green ));
 		color2 = COMPAT_TEXTURE( SamplerLUT2, vec2( blue2, green ));


### PR DESCRIPTION
Fixes #147 

Using GLSL reshade in Phantasy Star (SMS) in Genesis Plus GX causes all areas with maximum blue values to become black. I am using an Intel integrated ironlake GPU (i7-640LM CPU, in Thinkpad X201 Tablet) on Debian sid. I built libretro/retroarch from sources.

![LUT bug](https://user-images.githubusercontent.com/2400933/136438634-62f268c3-bd35-47de-8914-477476c7e3a5.png)

The correct image:

![LUT looks correct](https://user-images.githubusercontent.com/2400933/136438632-2508803a-1700-4702-b2cc-8ad47f42cf32.png)