### PR TITLE
Added alpha value missing

### DIFF
--- a/crt/shaders/zfast_crt.glsl
+++ b/crt/shaders/zfast_crt.glsl
@@ -193,7 +193,7 @@ void main()
 	colour.rgb*=float(tc.x > 0.0)*float(tc.y > 0.0); //why doesn't the driver do the right thing?
 #endif
 
-	FragColor.rgb = colour.rgb*mix(scanLineWeight*mask, scanLineWeightB, dot(colour.rgb,vec3(maskFade)));
+	FragColor.rgba = vec4(colour.rgb*mix(scanLineWeight*mask, scanLineWeightB, dot(colour.rgb,vec3(maskFade))),1.0);
 	
 } 
 #endif


### PR DESCRIPTION
While rgba (vec4) was expected, rgb only was sent out, resulting in alpha=0 hence black screen