### PR TITLE
improvements for the crt-blurPi shader

### DIFF
--- a/crt/crt-blurPi-soft.glslp
+++ b/crt/crt-blurPi-soft.glslp
@@ -11,7 +11,7 @@
 shaders = 2
 
 shader0 = shaders/crt-blurPi.glsl
-filter_linear0 = false
+filter_linear0 = true
 scale_type0 = source
 scale0 = 1.0
 
@@ -21,5 +21,5 @@ scale_type1 = viewport
 scale_x1 = 1.0
 scale_y1 = 1.0
 
-blurGain = "0.08"
+blurGain = "0.20"
 blurRadius = "0.50"

--- a/crt/crt-blurPi.glslp
+++ b/crt/crt-blurPi.glslp
@@ -11,7 +11,7 @@
 shaders = 2
 
 shader0 = shaders/crt-blurPi.glsl
-filter_linear0 = false
+filter_linear0 = true
 scale_type0 = source
 scale0 = 1.0
 
@@ -21,5 +21,5 @@ scale_type1 = viewport
 scale_x1 = 1.0
 scale_y1 = 1.0
 
-blurGain = "0.11"
-blurRadius = "0.51"
+blurGain = "0.20"
+blurRadius = "0.50"

--- a/crt/shaders/crt-blurPi.glsl
+++ b/crt/shaders/crt-blurPi.glsl
@@ -38,17 +38,14 @@ MIT license
 
 
 #pragma name crt-blurPi
-#pragma parameter rgbExtraGain "rgbExtraGain" 	0.0 	0.0 	1.0 	0.02
-#pragma parameter blurGain "blurGain" 			0.11 	0.0 	0.25 	0.01
-#pragma parameter blurRadius "blurRadius" 		0.51 	0.47 	0.7 	0.01
+#pragma parameter blurGain "blurGain" 			0.12 	0.0 	0.25 	0.01
+#pragma parameter blurRadius "blurRadius" 		0 		0		1.0 	0.05
 
 
 #ifdef PARAMETER_UNIFORM
-uniform COMPAT_PRECISION float rgbExtraGain;
 uniform COMPAT_PRECISION float blurGain;
 uniform COMPAT_PRECISION float blurRadius;
 #else
-#define rgbExtraGain 0.1
 #define blurGain 0.15
 #define blurRadius 1.5
 #endif
@@ -56,7 +53,6 @@ uniform COMPAT_PRECISION float blurRadius;
 COMPAT_ATTRIBUTE vec4 VertexCoord;
 COMPAT_ATTRIBUTE vec4 COLOR;
 COMPAT_ATTRIBUTE vec4 TexCoord;
-COMPAT_VARYING vec4 COL0;
 COMPAT_VARYING vec4 TEX0;
 COMPAT_VARYING vec2 dotSize;
 
@@ -70,7 +66,7 @@ uniform COMPAT_PRECISION vec2 InputSize; //size of GAME output
 void main(){
     gl_Position = VertexCoord.x * MVPMatrix[0] + VertexCoord.y * MVPMatrix[1] + VertexCoord.z * MVPMatrix[2] + VertexCoord.w * MVPMatrix[3];
     TEX0.xy = TexCoord.xy;
-    dotSize = blurRadius * 1.0 / TextureSize;
+    dotSize = (blurRadius) * (1.0 / TextureSize);
 }
 	
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -111,18 +107,14 @@ COMPAT_VARYING vec4 TEX0;
 COMPAT_VARYING vec2 dotSize;
 
 #ifdef PARAMETER_UNIFORM
-uniform COMPAT_PRECISION float rgbExtraGain;
 uniform COMPAT_PRECISION float blurGain;
-uniform COMPAT_PRECISION float blurRadius;
 #else
-#define rgbExtraGain 0.1
 #define blurGain 0.15
-#define blurRadius 1.5
 #endif
 
 void main(){
 
-	vec3 colN = COMPAT_TEXTURE(Texture, TEX0.xy + vec2(0.0, dotSize.y)).rgb;
+	vec3 colN = COMPAT_TEXTURE(Texture, TEX0.xy + vec2(0.0, dotSize.y)).rgb; 
 	vec3 colS = COMPAT_TEXTURE(Texture, TEX0.xy + vec2(0.0, -dotSize.y)).rgb;
 	vec3 colE = COMPAT_TEXTURE(Texture, TEX0.xy + vec2(dotSize.x, 0.0)).rgb;
 	vec3 colW = COMPAT_TEXTURE(Texture, TEX0.xy + vec2(-dotSize.x, 0.0)).rgb;
@@ -132,6 +124,6 @@ void main(){
 	float centerG = min(max(1.0 - 4.0 * blurGain, 0.0), 1.0);
     vec3 blur = centerG * color + blurGain * (colN + colS + colE + colW); 
     
-    FragColor = vec4( (1.0 + rgbExtraGain) * blur, 1);
+    FragColor = vec4(blur, 1);
 } 
 #endif

--- a/crt/shaders/crt-blurPiScanlines.glsl
+++ b/crt/shaders/crt-blurPiScanlines.glsl
@@ -115,7 +115,7 @@ void main(){
  		texCN = TEX0.y * TextureSize.y / InputSize.y;
  		scanLine = mod(texCN * OutputSize.y * 0.5, 1.0);
  	}
-	scanLine = (scanLine > 0.5) ? 1.0 + scanlineGain * 0.5 : 1.0 - scanlineGain * 0.5;
+	scanLine = (scanLine > 0.5) ? 1.0 + 0.1 * scanlineGain : 1.0 - scanlineGain * 0.50;
 	vec3 color = COMPAT_TEXTURE(Texture, TEX0.xy).rgb;
     FragColor = vec4( color * scanLine, 1.0 );
     


### PR DESCRIPTION
The blurRadius parameter has more granularity now, fixed scanlines burn issue.

Nearest
![Super Mario All-Stars (USA)-220403-155957](https://user-images.githubusercontent.com/167057/161436796-979b0eed-4b22-490d-8123-1682b206f8b5.png)

crt-blurPi
![Super Mario All-Stars (USA)-220403-155225](https://user-images.githubusercontent.com/167057/161436749-f046cdb6-7eea-42fd-9d02-64f527f9d849.png)

crt-blurPi-soft
![Super Mario All-Stars (USA)-220403-160149](https://user-images.githubusercontent.com/167057/161436853-8ae46508-ad06-4829-97b8-408ed3506417.png)

