### PR TITLE
zfast_crt_(no)geo - Scanline+Mask darken compensation

### DIFF
--- a/crt/zfast_crt_nogeo_svideo.glslp
+++ b/crt/zfast_crt_nogeo_svideo.glslp
@@ -1,0 +1,9 @@
+shaders = "1"
+
+shader0 = "shaders/zfast_crt_nogeo_svideo.glsl"
+filter_linear0 = "true"
+wrap_mode0 = "clamp_to_border"
+mipmap_input0 = "false"
+alias0 = ""
+float_framebuffer0 = "false"
+srgb_framebuffer0 = "false"


### PR DESCRIPTION
- Add zfast_crt_nogeo_svideo
- Compensate fit for scanline+mask darkening effect
- More optimizations (some parameters had to be dropped)