### PR TITLE
add inverse gamma to CRT-Geom

### DIFF
--- a/crt/shaders/crt-geom.glsl
+++ b/crt/shaders/crt-geom.glsl
@@ -21,6 +21,7 @@
 */
 
 #pragma parameter CRTgamma "CRTGeom Target Gamma" 2.4 0.1 5.0 0.1
+#pragma parameter INV "Inverse Gamma/CRT-Geom Gamma out" 1.0 0.0 1.0 1.0
 #pragma parameter monitorgamma "CRTGeom Monitor Gamma" 2.2 0.1 5.0 0.1
 #pragma parameter d "CRTGeom Distance" 1.6 0.1 3.0 0.1
 #pragma parameter CURVATURE "CRTGeom Curvature Toggle" 1.0 0.0 1.0 1.0
@@ -56,6 +57,7 @@
 #define lum 0.0
 #define interlace_detect 1.0
 #define SATURATION 1.0
+#define INV 1.0
 #endif
 
 #if defined(VERTEX)
@@ -304,6 +306,7 @@ uniform COMPAT_PRECISION float scanline_weight;
 uniform COMPAT_PRECISION float lum;
 uniform COMPAT_PRECISION float interlace_detect;
 uniform COMPAT_PRECISION float SATURATION;
+uniform COMPAT_PRECISION float INV;
 #endif
 
 float intersect(vec2 xy)
@@ -392,6 +395,17 @@ vec3 saturation (vec3 textureColor)
     return res;
 }
 
+#define pwr vec3(1.0/((-0.8*(1.0-scanline_weight)+1.0)*(-0.5*DOTMASK+1.0))-1.25)
+
+
+// Returns gamma corrected output, compensated for scanline+mask embedded gamma
+vec3 inv_gamma(vec3 col, vec3 power)
+{
+    vec3 cir  = col-1.0;
+         cir *= cir;
+         col  = mix(sqrt(col),sqrt(1.0-cir),power);
+    return col;
+}
 
 void main()
 {
@@ -494,8 +508,12 @@ vec3 dotMaskWeights = mix(
 	mul_res *= dotMaskWeights;
 
 // Convert the image gamma for display on our output device.
-	mul_res = pow(mul_res, vec3(1.0 / monitorgamma));
+if (INV == 1.0){ mul_res = inv_gamma(mul_res,pwr);} 
+	else mul_res = pow(mul_res, vec3(1.0/monitorgamma));
+        
         mul_res = saturation(mul_res);
+
+
 
 // Color the texel.
     output_dummy _OUT;

--- a/crt/shaders/fake-CRT-Geom-potato.glsl
+++ b/crt/shaders/fake-CRT-Geom-potato.glsl
@@ -2,7 +2,7 @@
 // written on an old netbook with 9 gflops
 // and runs 60-65 fps on 720p
 
-#pragma parameter SEVTWO "1080/720p Scanlines" 1.0 1.0 1.3333 0.3333
+#pragma parameter SEVTWO "1080/720p Scanlines" 2.0 1.3333 2.0 0.6666
 
 #define pi 3.1415926
 

--- a/crt/shaders/fake-CRT-Geom-potato.glsl
+++ b/crt/shaders/fake-CRT-Geom-potato.glsl
@@ -1,13 +1,10 @@
-// Simple scanlines and mask effect
-// original by hunterk, edit by DariusG
+// Simple scanlines and mask effect by DariusG
+// written on an old netbook with 9 gflops
+// and runs 60-65 fps on 720p
 
-///////////////////////  Runtime Parameters  ///////////////////////
-#pragma parameter SCANLINE "Scanline Intensity" 0.30 0.0 1.0 0.05
-#pragma parameter MSK "Mask Brightness" 0.7 0.0 1.0 0.05
+#pragma parameter SEVTWO "1080/720p Scanlines" 1.0 1.0 1.3333 0.3333
 
-
-
-#define pi 3.141592
+#define pi 3.1415926
 
 #if defined(VERTEX)
 
@@ -33,6 +30,8 @@ COMPAT_ATTRIBUTE vec4 TexCoord;
 COMPAT_VARYING vec4 COL0;
 COMPAT_VARYING vec4 TEX0;
 COMPAT_VARYING float fragpos;
+COMPAT_VARYING float scanpos;
+COMPAT_VARYING float cent;
 
 vec4 _oPosition1; 
 uniform mat4 MVPMatrix;
@@ -41,6 +40,7 @@ uniform COMPAT_PRECISION int FrameCount;
 uniform COMPAT_PRECISION vec2 OutputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION float SEVTWO;
 
 // compatibility #defines
 #define vTexCoord TEX0.xy
@@ -57,7 +57,10 @@ void main()
 {
     gl_Position = MVPMatrix * VertexCoord;
     TEX0.xy = TexCoord.xy*1.0001;
-    fragpos=TEX0.x*OutputSize.x*TextureSize.x/InputSize.x;
+    fragpos = TEX0.x*OutputSize.x*TextureSize.x/InputSize.x*pi;
+	float y = TEX0.y*SourceSize.y;
+	scanpos = y*pi*SEVTWO;
+	cent = (floor(y)+0.5)/SourceSize.y;
 }
 
 #elif defined(FRAGMENT)
@@ -91,6 +94,8 @@ uniform COMPAT_PRECISION vec2 InputSize;
 uniform sampler2D Texture;
 COMPAT_VARYING vec4 TEX0;
 COMPAT_VARYING float fragpos;
+COMPAT_VARYING float scanpos;
+COMPAT_VARYING float cent;
 
 // compatibility #defines
 #define Source Texture
@@ -111,29 +116,17 @@ uniform COMPAT_PRECISION float MSK;
 
 #endif
 
-// MSK mask calculation
-     
-      float Mask(float pos)
-      {
-      float mf = fract(pos * 0.5);
-
-      if (mf < 0.5) return (MSK);
-      else return (1.0);
-  
-      }
-
 void main()
 {
-    float OGL2Pos = vTexCoord.y*SourceSize.y;
-    float cent = floor(OGL2Pos)+0.5;
-    float ycoord = cent*SourceSize.w; 
-
-   vec3 res = texture2D(Source, vec2(vTexCoord.x, ycoord)).rgb;
-
-     res *= SCANLINE*sin(fract(vTexCoord.y*SourceSize.y)*pi)+1.0-SCANLINE ; 
-
-     res *= Mask(fragpos);
-
+    float ycoord = cent ; 
+    vec3 res = COMPAT_TEXTURE(Source, vec2(vTexCoord.x, ycoord)).rgb;
+	vec3 origin = res;
+	float lum = dot(vec3(0.3), res);
+	
+     res *= 0.4*sin(scanpos)+0.6 ; 
+     res *= 0.3*sin(fragpos)+0.7;
+	 res = mix(res, origin, lum);
+	 res *= mix(1.45,1.05,lum);
     FragColor = vec4(res,1.0);
 } 
 #endif


### PR DESCRIPTION
and  simplify fake-crt-geom-potato. Before it was a 90% clone of scanline.glsl so i thought either change it or delete it. So here it is an ultra fast version different from scanline.glsl.