### PR TITLE
fix crt-torridgristle

### DIFF
--- a/crt/shaders/torridgristle/ScanlineSimple.glsl
+++ b/crt/shaders/torridgristle/ScanlineSimple.glsl
@@ -110,7 +110,7 @@ void main()
     Scanline = 1.-abs(Scanline-0.5)*2.;
     Scanline = 1.-pow(1.-Scanline,2.0);
     
-    Scanline = clamp(sqrt(Scanline)-(1-HSBYIQHybrid),0.0,1.0);
+    Scanline = clamp(sqrt(Scanline)-(1.0-HSBYIQHybrid),0.0,1.0);
     Scanline /= HSBYIQHybrid;
 
 

--- a/crt/shaders/yee64.glsl
+++ b/crt/shaders/yee64.glsl
@@ -144,10 +144,10 @@ void main()
 	r9 = -r0.xxxx + c5;
 	r9 = r9 * r9;
 	r9 = r9 * c4.wwww;
-	r0.z = pow(2, r9.x);
+	r0.z = pow(2.0, r9.x);
 	r6.xyz = (r6 * r0.zzzz).xyz;
 	r6.xyz = (r6 * c3.zzzz).xyz;
-	r0.w = pow(2, r9.z);
+	r0.w = pow(2.0, r9.z);
 	r5.xyz = (r5 * r0.wwww + r6).xyz;
 	r0.w = r0.z + r0.w;
 	r6 = r7.zwzw + c4.zyxx;
@@ -162,15 +162,15 @@ void main()
 	r0.xy = (r0 * r0).xy;
 	r0.xy = (r0 * c6.yyyy).xy;
 	r1.zw = (r1 * c6.xyxy).zw;
-	r1.z = pow(2, r1.z);
-	r1.w = pow(2, r1.w);
+	r1.z = pow(2.0, r1.z);
+	r1.w = pow(2.0, r1.w);
 	r6.xyz = (r6 * r1.zzzz).xyz;
 	r5.xyz = (r6 * c3.zzzz + r5).xyz;
 	r6 = COMPAT_TEXTURE(Source, r3.xy);
 	r3 = COMPAT_TEXTURE(Source, r3.zw);
 	r3.xyz = (r3 * c3.zzzz).xyz;
-	r2.w = pow(2, r9.y);
-	r3.w = pow(2, r9.w);
+	r2.w = pow(2.0, r9.y);
+	r3.w = pow(2.0, r9.w);
 	r6.xyz = (r6 * r2.wwww).xyz;
 	r5.xyz = (r6 * c3.zzzz + r5).xyz;
 	r3.xyz = (r3 * r3.wwww + r5).xyz;
@@ -192,8 +192,8 @@ void main()
 	r5.xyz = (r8 * r0.zzzz + r5).xyz;
 	r2.xyz = (r2 * r2.wwww + r5).xyz;
 	r2.xyz = (r0.wwww * r2).xyz;
-	r0.x = pow(2, r0.x);
-	r0.y = pow(2, r0.y);
+	r0.x = pow(2.0, r0.x);
+	r0.y = pow(2.0, r0.y);
 	r2.xyz = (r2 * r0.xxxx + r3).xyz;
 	r3 = COMPAT_TEXTURE(Source, r7.xy);
 	r5 = COMPAT_TEXTURE(Source, r7.zw);
@@ -210,13 +210,13 @@ void main()
 	r0.w = r0.w * c6.w;
 	r0.w = fract(r0.w);
 	r1.xy = (r0.wwww + c7).xy;
-	r2.yz = (r1.y >= 0 ? c7.xzww : c7.xwzw).yz;
+	r2.yz = (r1.y >= 0.0 ? c7.xzww : c7.xwzw).yz;
 	r2.x = c8.w;
-	r1.xyz = (r1.x >= 0 ? r2 : c7.wzzw).xyz;
+	r1.xyz = (r1.x >= 0.0 ? r2 : c7.wzzw).xyz;
 	r1.xyz = (r0 * r1).xyz;
 	r2.z = c6.z;
 	r0.w = r2.z + -c2.y;
-	FragColor.xyz = (r0.w >= 0 ? r0 : r1).xyz;
+	FragColor.xyz = (r0.w >= 0.0 ? r0 : r1).xyz;
 	FragColor.w = -c3.x;
 } 
 #endif

--- a/crt/shaders/yeetron.glsl
+++ b/crt/shaders/yeetron.glsl
@@ -83,10 +83,10 @@ COMPAT_VARYING vec4 TEX0;
 
 vec4 cmp(vec4 src0, vec4 src1, vec4 src2) {
 	return vec4(
-		src0.x >= 0 ? src1.x : src2.x,
-		src0.y >= 0 ? src1.y : src2.y,
-		src0.z >= 0 ? src1.z : src2.z,
-		src0.w >= 0 ? src1.w : src2.w
+		src0.x >= 0.0 ? src1.x : src2.x,
+		src0.y >= 0.0 ? src1.y : src2.y,
+		src0.z >= 0.0 ? src1.z : src2.z,
+		src0.w >= 0.0 ? src1.w : src2.w
 	);
 }
 
@@ -128,9 +128,9 @@ void main()
 	r0.x = r0.x * c6.x;
 	r0.x = fract(r0.x);
 	r0.xy = (r0.xxxx + c6.yzzw).xy;
-	r1.yz = (r0.y >= 0 ? c7.xxyw : c7.xyxw).yz;
+	r1.yz = (r0.y >= 0.0 ? c7.xxyw : c7.xyxw).yz;
 	r1.x = c6.w;
-	r0.xyz = (r0.x >= 0 ? r1 : c7.yxxw).xyz;
+	r0.xyz = (r0.x >= 0.0 ? r1 : c7.yxxw).xyz;
 	r1.xy = (c1 * v0).xy;
 	r0.w = r1.y * c8.w + c8.w;
 	r0.w = fract(r0.w);
@@ -138,7 +138,7 @@ void main()
 	r2.y = sin(r0.w);
 	r1.zw = (abs(r2).yyyy + c4).zw;
 	r1.z = clamp(r1.z, 0.0, 1.0);
-	r0.w = r1.w >= 0 ? r1.z : c8.w;
+	r0.w = r1.w >= 0.0 ? r1.z : c8.w;
 	r2 = fract(r1.xyxy);
 	r1.xy = (r1 + -r2.zwzw).xy;
 	r2 = r2 + c8.xxyy;
@@ -151,7 +151,7 @@ void main()
 	r4.x = min(r3.x, c3.z);
 	r1.zw = (-abs(r1).wwww + c3).zw;
 	r1.z = clamp(r1.z, 0.0, 1.0);
-	r1.z = r1.w >= 0 ? r1.z : c8.w;
+	r1.z = r1.w >= 0.0 ? r1.z : c8.w;
 	r4.y = r0.w + r1.z;
 	r0.w = r0.w * r4.x;
 	r1.z = r1.z * r4.x;
@@ -172,6 +172,6 @@ void main()
 	r0.xyz = (r0 * r3).xyz;
 	r1.z = c5.z;
 	r0.w = r1.z + -c2.y;
-	FragColor.xyz = (r0.w >= 0 ? r3 : r0).xyz;
+	FragColor.xyz = (r0.w >= 0.0 ? r3 : r0).xyz;
 } 
 #endif


### PR DESCRIPTION
It was failing to load before

_INFO] Shader log: 0:116(35): error: could not implicitly convert operands to arithmetic operator
0:116(19): error: operands to arithmetic operators must be numeric
0:116(13): error: no matching function for call to `clamp(error, float, float)';_