### PR TITLE
Update simple_color_controls.glsl

### DIFF
--- a/misc/shaders/simple_color_controls.glsl
+++ b/misc/shaders/simple_color_controls.glsl
@@ -274,7 +274,7 @@ if (CS != 0.0){
     if (CS == 3.0) col *= NTSC_J;
     col /= vec3(0.24,0.69,0.07);
     col *= vec3(0.29,0.60,0.11); 
-
+  col = clamp(col,0.0,2.0);
 }
    if (SEGA == 1.0) col *= 1.0625;
 


### PR DESCRIPTION
FIX: Some cards will produce black colors in areas that min color is below 0.0. 
Colors now are 90% (RGB cannot produce so rich reds as CRT) spot on compared to my 20" CRT which is a PAL TV, PAL setting tested on shader. 