### PR TITLE
crt-sines / crt-consumer: move glow code to be included in mask/scanlines

### DIFF
--- a/crt/shaders/crt-consumer/crt-consumer.glsl
+++ b/crt/shaders/crt-consumer/crt-consumer.glsl
@@ -38,7 +38,7 @@ any later version.
 #pragma parameter bogus_col " [ COLORS ] " 0.0 0.0 0.0 0.0
 #pragma parameter GAMMA_OUT "Gamma Out" 2.2 0.0 4.0 0.05
 #pragma parameter crt_lum "CRT Luminances On/Off" 1.0 0.0 1.0 1.0
-#pragma parameter glow "Glow Strength" 0.08 0.0 1.0 0.01
+#pragma parameter glow "Glow Strength" 0.12 0.0 1.0 0.01
 #pragma parameter brightboost1 "Bright boost dark pixels" 1.0 0.0 3.0 0.05
 #pragma parameter brightboost2 "Bright boost bright pixels" 1.0 0.0 3.0 0.05
 #pragma parameter sat "Saturation" 1.0 0.0 2.0 0.05
@@ -587,6 +587,8 @@ color =clamp(color, 0.0,1.0);
   x = (vTexCoord.x*SourceSize.x/InputSize.x-0.5);  // range -0.5 to 0.5, 0.0 being center of screen
   x = x*x*1.5;    // curved response: higher values (more far from center) get higher results.
 }
+    vec3 Glow = COMPAT_TEXTURE(Source,pC4).rgb;
+    color += Glow*glow;
     color = color*sw(f,lum,x) + color*sw(1.0-f,lum,x);
     
     color*=mix(mask(maskpos.xy*1.0001,color,lum), vec3(1.0),lum*0.9);
@@ -598,8 +600,7 @@ if (crt_lum == 1.0){
     // 0.29/0.24, 0.6/0.69, 0.11/0.07
      color *= vec3(1.208,0.8695,1.5714); 
    }
-    vec3 Glow = COMPAT_TEXTURE(Source,pC4).rgb;
-    color += Glow*glow;
+
     color=pow(color,vec3(1.0/GAMMA_OUT));
 
     if (sat != 1.0) color = saturation(color, lum, lumWeighting);

--- a/crt/shaders/crt-consumer/glow_x.glsl
+++ b/crt/shaders/crt-consumer/glow_x.glsl
@@ -111,6 +111,12 @@ uniform COMPAT_PRECISION float glow;
 
 void main()
 {
+
+/*
+  use hardware hack for 9-tap blur using linear and 5 passes, see:
+  https://www.rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
+*/
+
 vec3 res0 = COMPAT_TEXTURE(Source,vTexCoord).rgb*w0;
      res0 += COMPAT_TEXTURE(Source,vTexCoord+psx*one).rgb*w1;
      res0 += COMPAT_TEXTURE(Source,vTexCoord-psx*one).rgb*w1;

--- a/crt/shaders/crt-consumer/glow_y.glsl
+++ b/crt/shaders/crt-consumer/glow_y.glsl
@@ -111,6 +111,12 @@ uniform COMPAT_PRECISION float glow;
 
 void main()
 {
+
+/*
+  use hardware hack for 9-tap blur using linear and 5 passes, see:
+  https://www.rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/
+*/
+
 vec3 res0 = COMPAT_TEXTURE(Source,vTexCoord).rgb*w0;
      res0 += COMPAT_TEXTURE(Source,vTexCoord+psy*one).rgb*w1;
      res0 += COMPAT_TEXTURE(Source,vTexCoord-psy*one).rgb*w1;

--- a/crt/shaders/crt-sines.glsl
+++ b/crt/shaders/crt-sines.glsl
@@ -30,16 +30,16 @@
   v1.1: switched to lanczos4 taps filter
 */
 
-#pragma parameter glow "Glow strength" 0.10 0.0 1.0 0.01
+#pragma parameter glow "Glow strength" 0.12 0.0 1.0 0.01
 #pragma parameter CURV "Curvature On/Off" 1.0 0.0 1.0 1.0
-#pragma parameter scanl "Scanlines/Mask Low" 0.35 0.0 0.5 0.05
-#pragma parameter scanh "Scanlines/Mask High" 0.15 0.0 0.5 0.05
+#pragma parameter scanl "Scanlines/Mask Low" 0.3 0.0 0.5 0.05
+#pragma parameter scanh "Scanlines/Mask High" 0.1 0.0 0.5 0.05
 #pragma parameter SIZE "Mask Type, 2:Fine, 3:Coarse" 3.0 2.0 3.0 1.0
 #pragma parameter slotm "Slot Mask On/Off" 1.0 0.0 1.0 1.0
 #pragma parameter slotw "Slot Mask Width" 3.0 2.0 3.0 1.0
 #pragma parameter bogus_col " [ COLORS ] " 0.0 0.0 0.0 0.0
 #pragma parameter Trin "CRT Colors" 0.0 0.0 1.0 1.0
-#pragma parameter boostd "Boost Dark Colors" 1.3 1.0 2.0 0.05
+#pragma parameter boostd "Boost Dark Colors" 1.45 1.0 2.0 0.05
 #pragma parameter sat "Saturation" 1.0 0.0 2.0 0.05
 #pragma parameter bogus_conv " [ CONVERGENCE ] " 0.0 0.0 0.0 0.0
 #pragma parameter RX "Convergence Horiz." 0.0 -2.0 2.0 0.05
@@ -150,7 +150,6 @@ COMPAT_VARYING float dx;
 // compatibility #defines
 #define Source Texture
 uniform sampler2D PassPrev3Texture;
-uniform sampler2D PassPrevTexture;
 #define vTexCoord TEX0.xy
 
 #ifdef PARAMETER_UNIFORM
@@ -209,7 +208,7 @@ else pos = vTexCoord;
   vec2 p = ogl2pos+0.5;
   vec2 i = floor(p);
   vec2 f = p - i;        // -0.5 to 0.5
-       f = f*f*f*(3.0-2.0*f);
+       f = f*f*f*(4.0-3.0*f);
        f.y *= f.y;
        p = (i + f-0.5)*ps;
 
@@ -225,18 +224,19 @@ else pos = vTexCoord;
   
   res = res*0.5 + 0.5*vec3(convrb.x,convg,convrb.y);   
 
- float w = dot(vec3(0.28),res);
- float scan = mix(scanl,scanh,w);
+ float w = dot(vec3(0.25),res);
+ float scan = mix(scanl,scanh,w)+x;
  float mask = scan*1.333;
 
 // apply vignette here
- float scn = (scan+x)*sin((ogl2pos.y+0.5)*tau)+1.0-scan+x;
+ float scn = scan*sin((ogl2pos.y+0.5)*tau)+1.0-scan;
  float msk = mask*sin(fragpos*pi)+1.0-mask;
     
     float sl = 1.0; vec2 xy = vec2(0.0);
     if (slotm == 1.0){
     xy = vTexCoord*OutputSize.xy*scale; 
     sl = slot(xy, mask);
+    msk = msk*sl;
     }
 
     if(Trin == 1.0) { 
@@ -246,7 +246,7 @@ else pos = vTexCoord;
     res *= mix(boostd, 1.0, w);
     vec3 Glow = COMPAT_TEXTURE(Source,pos).rgb;
     res = res + Glow*glow;  
-    res *= scn*msk*sl;
+    res *= scn*msk;
 
     res = sqrt(res);
     float gray = dot(vec3(0.3,0.6,0.1),res);

--- a/crt/shaders/crt-sines.glsl
+++ b/crt/shaders/crt-sines.glsl
@@ -30,7 +30,7 @@
   v1.1: switched to lanczos4 taps filter
 */
 
-#pragma parameter glow "Glow strength" 0.08 0.0 1.0 0.01
+#pragma parameter glow "Glow strength" 0.10 0.0 1.0 0.01
 #pragma parameter CURV "Curvature On/Off" 1.0 0.0 1.0 1.0
 #pragma parameter scanl "Scanlines/Mask Low" 0.35 0.0 0.5 0.05
 #pragma parameter scanh "Scanlines/Mask High" 0.15 0.0 0.5 0.05
@@ -243,14 +243,14 @@ else pos = vTexCoord;
     res *= vec3(1.0,0.92,1.08); 
     res = clamp(res,0.0,1.0);
     }
-
-    res *= scn*msk*sl;
-    float gray = dot(vec3(0.3,0.6,0.1),res);
-    res  = mix(vec3(gray),res,sat);
     res *= mix(boostd, 1.0, w);
     vec3 Glow = COMPAT_TEXTURE(Source,pos).rgb;
-    res = res + Glow*glow;
+    res = res + Glow*glow;  
+    res *= scn*msk*sl;
+
     res = sqrt(res);
+    float gray = dot(vec3(0.3,0.6,0.1),res);
+    res  = mix(vec3(gray),res,sat);
     if (corn.y <= corn.x && CURV == 1.0 || corn.x < 0.0001 && CURV == 1.0 )res = vec3(0.0);
 
 FragColor.rgb = res;    


### PR DESCRIPTION
More realistic and closer to how my crt looks in reality. That's a more organic look that looks like it belongs to the shader inner ecosystem.