### PR TITLE
Add shader for smoothing hard pixel edges.

### DIFF
--- a/pixel-art-scaling/edge1pixel.glslp
+++ b/pixel-art-scaling/edge1pixel.glslp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = shaders/edge1pixel.glsl
+filter_linear0 = true

--- a/pixel-art-scaling/shaders/edge1pixel.glsl
+++ b/pixel-art-scaling/shaders/edge1pixel.glsl
@@ -1,0 +1,130 @@
+#version 130
+
+// Interpolate a single row of display pixels between each pair of adjacent source pixels.
+// by decavoid
+
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+COMPAT_VARYING vec2 INVERSE_SCALE;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+// vertex compatibility #defines
+#define vTexCoord TEX0.xy
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    COL0 = COLOR;
+    TEX0.xy = TexCoord.xy;
+    INVERSE_SCALE = InputSize / OutputSize;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+COMPAT_VARYING vec2 INVERSE_SCALE;
+
+// fragment compatibility #defines
+#define Source Texture
+#define vTexCoord TEX0.xy
+
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+
+vec2 isInside(vec2 v, vec2 left, vec2 right)
+{
+	return step(left, v) - step(right, v);
+}
+
+// uncomment to see a red grid of modified pixels
+//#define DEBUG_DRAW_EDGES
+
+void main()
+{
+	vec2 pixelCoords = vTexCoord * TextureSize.xy; // NES x: [0; 256], y: [0; 240]
+	vec2 iPixelCoords = floor(pixelCoords);
+	vec2 coordAtPixelCenter = (iPixelCoords + vec2(0.5));
+	vec2 coordBetweenPixels = round(pixelCoords);
+	vec2 f = pixelCoords - iPixelCoords + vec2(1e-4);
+	vec2 isFractionInside = isInside(f, 0.5 * INVERSE_SCALE, 1.0 - 0.5 * INVERSE_SCALE);
+
+/*
+	Equivalent:
+	if (isFractionInside.x)
+	{
+		// shift coord to the nearest pixel center to prevent interpolation
+		newCoord.x = coordAtPixelCenter.x;
+	}
+	else
+	{
+		// shift exactly between pixels for perfect interpolation
+		newCoord.x = coordBetweenPixels.x;
+	}
+*/
+
+	vec2 newCoord = isFractionInside * coordAtPixelCenter + (1 - isFractionInside) * coordBetweenPixels;
+	vec2 newTexCoord = newCoord / TextureSize;
+	FragColor = vec4(COMPAT_TEXTURE(Source, newTexCoord).rgb, 1.0);
+
+#ifdef DEBUG_DRAW_EDGES
+	if (isFractionInside.x + isFractionInside.y < 2)
+		FragColor.r = 1;
+#endif
+}
+
+#endif


### PR DESCRIPTION
Here is a new shader that a made for playing low resolution games (e.g. NES) on a high resolution PC monitor. It smoothes hard edges between scaled pixels by changing (linear interpolation) only a single row/column of final scaled pixels between adjacent source pixels. Other (non-edge) pixels remain untouched. Every other shader I tried performed pixel edge smoothing by changing too many rows (2 or more).

Comparison.
Game resolution: 256x240. Output resolution: 1536x1200. Integer scaling: X-axis - x6, Y-axis -  x5.

Shader off:
![shader-off](https://github.com/user-attachments/assets/3eecf793-b7cc-4bbb-9a8f-cb5640a84388)

Shader on:
![shader-on](https://github.com/user-attachments/assets/eb6d6be8-451e-421a-a94e-a45f2ad45f0c)
Online comparison: https://imgsli.com/MjkxNDM2

Shader off (10x zoom):
![zoom-shader-off](https://github.com/user-attachments/assets/a1e4a375-7c57-4f3b-a9fd-8b366f32e8e1)

Shader on (10x zoom):
![zoom-shader-on](https://github.com/user-attachments/assets/42604166-81d4-463b-8bfb-de3029727599)
Online comparison: https://imgsli.com/MjkxNDM0