### PR TITLE
Add edgeNpixels shader for smoothing hard pixel edges

### DIFF
--- a/pixel-art-scaling/edgeNpixels.glslp
+++ b/pixel-art-scaling/edgeNpixels.glslp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = shaders/edgeNpixels.glsl
+filter_linear0 = true


### PR DESCRIPTION
This is a configurable variant of edge1pixel shader (#489). It allows to insert more than 1 linearly interpolated pixel rows between adjacent source pixels by changing "Pixel Count" shader parameter, range [1; 8].

Comparison.
Game resolution: 256x240. Output resolution: 2048x1440. Integer scaling: X-axis - 8x, Y-axis - 6x.

Shader off:
![orig](https://github.com/user-attachments/assets/6d5c771b-7771-469a-8f99-eb48722ad1e7)
Shader on, Pixel Count = 1 (same result as edge1pixel shader):
![x1](https://github.com/user-attachments/assets/ee01d518-ce0b-4d76-a037-63b56551fcd3)
Shader on, Pixel Count = 2:
![x2](https://github.com/user-attachments/assets/6278445c-fb55-4c28-b406-41b450a43ed8)
Shader on, Pixel Count = 3:
![x3](https://github.com/user-attachments/assets/7159fd5d-4929-44fd-ac35-5153cdf29c81)
Shader on, Pixel Count = 4:
![x4](https://github.com/user-attachments/assets/c32549d4-b950-46db-9e70-5c8857029c1c)

Shader off, zoom x10:
![zorig](https://github.com/user-attachments/assets/370d4657-660f-4ac3-8919-58b64bd0bf12)
Shader on, Pixel Count = 1 (same result as edge1pixel shader), zoom x10:
![zx1](https://github.com/user-attachments/assets/e2a2b2c7-5426-40aa-8d41-3709eaaae76f)
Shader on, Pixel Count = 2, zoom x10
![zx2](https://github.com/user-attachments/assets/55d99e6b-7d44-4180-8dcc-be487bba0d4a)
Shader on, Pixel Count = 3, zoom x10
![zx3](https://github.com/user-attachments/assets/f0a92236-3d27-49cd-9067-1ce29284010f)
Shader on, Pixel Count = 4, zoom x10
![zx4](https://github.com/user-attachments/assets/f43ca1fc-7d28-4f85-bca5-88bbe8641e8f)
