### PR TITLE
edgeNpixels: fix shader compilation errors on iPhone

### DIFF
--- a/pixel-art-scaling/shaders/edge1pixel.glsl
+++ b/pixel-art-scaling/shaders/edge1pixel.glsl
@@ -44,22 +44,11 @@ uniform COMPAT_PRECISION vec2 InputSize;
 void main()
 {
     gl_Position = MVPMatrix * VertexCoord;
-    COL0 = COLOR;
     TEX0.xy = TexCoord.xy * TextureSize.xy; // NES x: [0; 256], y: [0; 240]
     INVERSE_SCALE_HALF = InputSize / OutputSize * 0.5;
 }
 
 #elif defined(FRAGMENT)
-
-#if __VERSION__ >= 130
-#define COMPAT_VARYING in
-#define COMPAT_TEXTURE texture
-out vec4 FragColor;
-#else
-#define COMPAT_VARYING varying
-#define FragColor gl_FragColor
-#define COMPAT_TEXTURE texture2D
-#endif
 
 #ifdef GL_ES
 #ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -70,6 +59,16 @@ precision mediump float;
 #define COMPAT_PRECISION mediump
 #else
 #define COMPAT_PRECISION
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
 #endif
 
 uniform COMPAT_PRECISION int FrameDirection;
@@ -118,7 +117,7 @@ void main()
 	}
 */
 
-	vec2 newCoord = isFractionInside * coordAtPixelCenter + (1 - isFractionInside) * coordBetweenPixels;
+	vec2 newCoord = isFractionInside * coordAtPixelCenter + (1.0 - isFractionInside) * coordBetweenPixels;
 	vec2 newTexCoord = newCoord * SourceSize.zw;
 	FragColor = vec4(COMPAT_TEXTURE(Source, newTexCoord).rgb, 1.0);
 

--- a/pixel-art-scaling/shaders/edgeNpixels.glsl
+++ b/pixel-art-scaling/shaders/edgeNpixels.glsl
@@ -54,7 +54,6 @@ uniform COMPAT_PRECISION float PixelCount;
 void main()
 {
     gl_Position = MVPMatrix * VertexCoord;
-    COL0 = COLOR;
     TEX0.xy = TexCoord.xy * TextureSize.xy; // NES x: [0; 256], y: [0; 240]
 
     sizeScale = vec4(OutputSize / InputSize, InputSize / OutputSize);
@@ -63,16 +62,6 @@ void main()
 }
 
 #elif defined(FRAGMENT)
-
-#if __VERSION__ >= 130
-#define COMPAT_VARYING in
-#define COMPAT_TEXTURE texture
-out vec4 FragColor;
-#else
-#define COMPAT_VARYING varying
-#define FragColor gl_FragColor
-#define COMPAT_TEXTURE texture2D
-#endif
 
 #ifdef GL_ES
 #ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -83,6 +72,16 @@ precision mediump float;
 #define COMPAT_PRECISION mediump
 #else
 #define COMPAT_PRECISION
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
 #endif
 
 uniform COMPAT_PRECISION int FrameDirection;
@@ -122,10 +121,10 @@ void main()
 	// from range [-interpolationRangeHalf.x; interpolationRangeHalf.x]
 	// to range (-0.5; 0.5)
 	vec2 segmentIndex = floor((origOffset + interpolationRangeHalf) * sizeScale.xy);
-	vec2 transformedOffset = stepPerRow * (segmentIndex + 1) - 0.5;
+	vec2 transformedOffset = stepPerRow * (segmentIndex + 1.0) - 0.5;
 	vec2 interpolatedCoord = coordBetweenPixels + transformedOffset;
 
-	vec2 newCoord = (1 - needInterpolate) * coordAtPixelCenter + needInterpolate * interpolatedCoord;
+	vec2 newCoord = (1.0 - needInterpolate) * coordAtPixelCenter + needInterpolate * interpolatedCoord;
 	vec2 newTexCoord = newCoord * SourceSize.zw;
 
 	FragColor = vec4(COMPAT_TEXTURE(Source, newTexCoord).rgb, 1.0);


### PR DESCRIPTION
This change fixes compilation errors in shaders edge1pixels, edgeNpixels when running on iPhone (GLSL version 300 es).

```
ERROR: 0:60: 'vec4' : declaration must include a precision specifier for type
ERROR: 0:124: '-' does not operate on 'int' and 'vec2'
```