### PR TITLE
Refactor of luminance threshold logic

### DIFF
--- a/handheld/gb-dot-matrix-white.glslp
+++ b/handheld/gb-dot-matrix-white.glslp
@@ -35,7 +35,7 @@ scale_y2 = "1.000000"
 
 
 textures = "COLOR_PALETTE;BACKGROUND"
-COLOR_PALETTE = shaders/gameboy/resources/sample-palettes/w-palette.png
+COLOR_PALETTE = shaders/gameboy/resources/sample-palettes/b-w-palette.png
 COLOR_PALETTE_linear = "false"
 COLOR_PALETTE_wrap_mode = "clamp_to_border"
 COLOR_PALETTE_mipmap = "false"

--- a/handheld/shaders/gameboy-dm-color/gb-pass0.glsl
+++ b/handheld/shaders/gameboy-dm-color/gb-pass0.glsl
@@ -144,6 +144,9 @@ COMPAT_VARYING vec4 TEX0;
 COMPAT_VARYING vec2 dot_size;
 COMPAT_VARYING vec2 one_texel;
 
+// compatibility #defines
+#define Source Texture
+#define vTexCoord TEX0.xy
 #define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
 #define outsize vec4(OutputSize, 1.0 / OutputSize)
 
@@ -155,12 +158,16 @@ uniform COMPAT_PRECISION float color_toggle;
 uniform COMPAT_PRECISION float negative_toggle;
 uniform COMPAT_PRECISION float desaturate_toggle;
 #endif
-  
+
+ 
+////////////////////////////////////////////////////////////////////////////////
+//fragment definitions                                                        //
+////////////////////////////////////////////////////////////////////////////////
+ 
 
 void main()
 {
     vec3 foreground_color = COMPAT_TEXTURE(COLOR_PALETTE, vec2(0.75, 0.5)).rgb;
-
     vec3 curr_rgb_original = COMPAT_TEXTURE(Texture, TEX0.xy).rgb;
     vec3 curr_rgb_negative = vec3(1.0) - curr_rgb_original;
     vec3 curr_rgb = mix(curr_rgb_original, curr_rgb_negative, step(0.5, negative_toggle));
@@ -170,29 +177,41 @@ void main()
         is_on_dot = 1.0;
 
     vec3 input_rgb = curr_rgb;
-    input_rgb += (texture2D(PrevTexture, TEX0.xy).rgb - input_rgb) * response_time;
-    input_rgb += (texture2D(Prev1Texture, TEX0.xy).rgb - input_rgb) * pow(response_time, 2.0);
-    input_rgb += (texture2D(Prev2Texture, TEX0.xy).rgb - input_rgb) * pow(response_time, 3.0);
-    input_rgb += (texture2D(Prev3Texture, TEX0.xy).rgb - input_rgb) * pow(response_time, 4.0);
-    input_rgb += (texture2D(Prev4Texture, TEX0.xy).rgb - input_rgb) * pow(response_time, 5.0);
-    input_rgb += (texture2D(Prev5Texture, TEX0.xy).rgb - input_rgb) * pow(response_time, 6.0);
-    input_rgb += (texture2D(Prev6Texture, TEX0.xy).rgb - input_rgb) * pow(response_time, 7.0);
 
+    // Apply response time smoothing with a decreasing impact of each previous frame
+    float base_factor = pow(response_time, 2.0); // Adjust the exponent for a smoother curve
+
+    input_rgb += (COMPAT_TEXTURE(PrevTexture, TEX0.xy).rgb - input_rgb) * response_time;
+    input_rgb += (COMPAT_TEXTURE(Prev1Texture, TEX0.xy).rgb - input_rgb) * base_factor * 0.5;
+    input_rgb += (COMPAT_TEXTURE(Prev2Texture, TEX0.xy).rgb - input_rgb) * base_factor * 0.25;
+    input_rgb += (COMPAT_TEXTURE(Prev3Texture, TEX0.xy).rgb - input_rgb) * base_factor * 0.125;
+    input_rgb += (COMPAT_TEXTURE(Prev4Texture, TEX0.xy).rgb - input_rgb) * base_factor * 0.0625;
+    input_rgb += (COMPAT_TEXTURE(Prev5Texture, TEX0.xy).rgb - input_rgb) * base_factor * 0.03125;
+    input_rgb += (COMPAT_TEXTURE(Prev6Texture, TEX0.xy).rgb - input_rgb) * base_factor * 0.015625;
+
+    // Calculate the alpha based on the weighted input RGB
     float rgb_to_alpha = (input_rgb.r + input_rgb.g + input_rgb.b) / 3.0 + (is_on_dot * baseline_alpha);
-    
+
+    // Apply color toggle and mix the input color with the foreground color
     vec3 final_color = mix(input_rgb, foreground_color, color_toggle);
 
-    // luminance calculation
+    // Luminance calculation for desaturation
     float luminance = dot(final_color, vec3(0.299, 0.587, 0.114));
-    final_color = mix(final_color, vec3(luminance), desaturate_toggle); // Mix color
+    final_color = mix(final_color, vec3(luminance), desaturate_toggle);
 
-    vec4 out_color = vec4(final_color, rgb_to_alpha);  
+    vec4 out_color = vec4(final_color, rgb_to_alpha);
 
+// Determine if all elements should be considered as "on dot" based on color_toggle
+if (color_toggle > 0.5) {
+    out_color.a *= is_on_dot; // Treat all pixels as "on dot"
+} else {
+    // Adjust alpha transparency based on luminance threshold
     if (dot(input_rgb, vec3(0.299, 0.587, 0.114)) > 0.85) {
-        out_color.a = 1.0;
+        out_color.a = 1.0; // Fully opaque if luminance is high enough
     } else {
-        out_color.a *= is_on_dot;
+        out_color.a *= is_on_dot; // Only apply dot masking if necessary
     }
+}
 
     gl_FragColor = out_color;
 }


### PR DESCRIPTION
This (again, sorry) updates the alpha transparency logic for the non-color versions of the Game Boy shaders. The previous version had some issues with how response time was calculated leading to visual glitches with side-scrolling games (shimmering).

Now, if color_toggle is on (value 1.0), all pixels are treated as "on dot," regardless of the luminance value. If color_toggle is off (0.0), the luminance of the pixel is evaluated. If the luminance is above 0.85, the alpha is set to fully opaque. Otherwise, dot masking is applied (is on dot). This behavior improves visuals across GB modes, especially for white text on colored backgrounds in GBC and GBA shaders, ensuring no dots appear on white backgrounds for better text legibility and visual style.

Additionally, I replaced a missing texture file for the Game Boy white shader that was not included in the already avalible textures.