### PR TITLE
Pixel AA v1.7

### DIFF
--- a/pixel-art-scaling/pixel_aa.glslp
+++ b/pixel-art-scaling/pixel_aa.glslp
@@ -1,5 +1,9 @@
-shaders = 1
+shaders = 2
 
-shader0 = shaders/pixel_aa/pixel_aa.glsl
-filter_linear0 = true
-scale_type0 = viewport
+shader0 = shaders/pixel_aa/to_lin.glsl
+filter_linear0 = false
+scale_type0 = source
+
+shader1 = shaders/pixel_aa/pixel_aa.glsl
+filter_linear1 = true
+scale_type1 = viewport

--- a/pixel-art-scaling/pixel_aa_fast.glslp
+++ b/pixel-art-scaling/pixel_aa_fast.glslp
@@ -1,5 +1,9 @@
-shaders = 1
+shaders = 2
 
-shader0 = shaders/pixel_aa/pixel_aa_fast.glsl
+shader0 = shaders/pixel_aa/to_lin_fast.glsl
 filter_linear0 = false
-scale_type0 = viewport
+scale_type0 = source
+
+shader1 = shaders/pixel_aa/pixel_aa_fast.glsl
+filter_linear1 = true
+scale_type1 = viewport

--- a/pixel-art-scaling/pixel_aa_no_gamma_correction.glslp
+++ b/pixel-art-scaling/pixel_aa_no_gamma_correction.glslp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/pixel_aa/pixel_aa_no_gamma_correction.glsl
+filter_linear0 = true
+scale_type0 = viewport

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa.glsl
@@ -69,10 +69,10 @@ out PREC_MED vec2 tx_per_px;
 out PREC_MED vec2 tx_to_uv;
 
 void main() {
-  gl_Position = MVPMatrix * VertexCoord;
-  tx_coord = TexCoord.xy * TextureSize;
-  tx_per_px = InputSize / OutputSize;
-  tx_to_uv = 1.0 / TextureSize;
+    gl_Position = MVPMatrix * VertexCoord;
+    tx_coord = TexCoord.xy * TextureSize;
+    tx_per_px = InputSize / OutputSize;
+    tx_to_uv = 1.0 / TextureSize;
 }
 
 #elif defined(FRAGMENT)
@@ -101,84 +101,79 @@ out PREC_LOW vec4 FragColor;
 
 // Similar to smoothstep, but has a configurable slope at x = 0.5.
 // Original smoothstep has a slope of 1.5 at x = 0.5
-PREC_MED vec2 slopestep(PREC_MED vec2 edge0, PREC_MED vec2 edge1,
-                        PREC_MED vec2 x, PREC_MED float slope) {
-  x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
-  vec2 s = sign(x - 0.5);
-  vec2 o = (1.0 + s) * 0.5;
-  return o - 0.5 * s * pow(2.0 * (o - s * x), vec2(slope));
+PREC_MED vec2 slopestep(PREC_MED vec2 edge0, PREC_MED vec2 edge1, PREC_MED vec2 x,
+                        PREC_MED float slope) {
+    x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+    vec2 s = sign(x - 0.5);
+    vec2 o = (1.0 + s) * 0.5;
+    return o - 0.5 * s * pow(2.0 * (o - s * x), vec2(slope));
 }
 
 // Function to get a pixel value, taking into consideration possible subpixel
 // interpolation.
-PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px,
-                       PREC_MED vec2 tx_to_uv, PREC_MED vec2 tx_coord,
-                       PREC_MED float sharpness, bool sample_subpx,
-                       PREC_LOW int subpx_orientation,
-                       PREC_LOW int screen_rotation) {
-  PREC_MED float sharpness_upper = min(1.0, sharpness);
-  PREC_MED vec2 sharp_lb = sharpness_upper * (0.5 - 0.5 * tx_per_px);
-  PREC_MED vec2 sharp_ub =
-      1.0 - sharpness_upper * (1.0 - (0.5 + 0.5 * tx_per_px));
-  PREC_MED float sharpness_lower = max(1.0, sharpness);
+PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px, PREC_MED vec2 tx_to_uv,
+                       PREC_MED vec2 tx_coord, PREC_MED float sharpness, bool sample_subpx,
+                       PREC_LOW int subpx_orientation, PREC_LOW int screen_rotation) {
+    PREC_MED float sharpness_upper = min(1.0, sharpness);
+    PREC_MED vec2 sharp_lb = sharpness_upper * (0.5 - 0.5 * tx_per_px);
+    PREC_MED vec2 sharp_ub = 1.0 - sharpness_upper * (1.0 - (0.5 + 0.5 * tx_per_px));
+    PREC_MED float sharpness_lower = max(1.0, sharpness);
 
-  PREC_MED vec2 period, phase, offset;
-  if (sample_subpx) {
-    // Subpixel sampling: Shift the sampling by 1/3rd of an output pixel for
-    // each subpixel, assuming that the output size is at monitor
-    // resolution.
-    // Compensate for possible rotation of the screen in certain cores.
-    const vec4 rot_corr = vec4(1.0, 0.0, -1.0, 0.0);
-    PREC_MED vec2 sub_tx_offset =
-        tx_per_px / 3.0 *
-        vec2(rot_corr[(screen_rotation + subpx_orientation) % 4],
-             rot_corr[(screen_rotation + subpx_orientation + 3) % 4]);
+    PREC_MED vec2 period, phase, offset;
+    if (sample_subpx) {
+        // Subpixel sampling: Shift the sampling by 1/3rd of an output pixel for
+        // each subpixel, assuming that the output size is at monitor
+        // resolution.
+        // Compensate for possible rotation of the screen in certain cores.
+        const vec4 rot_corr = vec4(1.0, 0.0, -1.0, 0.0);
+        PREC_MED vec2 sub_tx_offset = tx_per_px / 3.0 *
+                                      vec2(rot_corr[(screen_rotation + subpx_orientation) % 4],
+                                           rot_corr[(screen_rotation + subpx_orientation + 3) % 4]);
 
-    PREC_LOW vec3 res;
+        PREC_LOW vec3 res;
 
-    // Red
-    period = floor(tx_coord - sub_tx_offset - 0.5);
-    phase = tx_coord - sub_tx_offset - 0.5 - period;
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
-    res.r = texture(tex, (period + 0.5 + offset) * tx_to_uv).r;
-    // Green
-    period = floor(tx_coord - 0.5);
-    phase = tx_coord - 0.5 - period;
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
-    res.g = texture(tex, (period + 0.5 + offset) * tx_to_uv).g;
-    // Blue
-    period = floor(tx_coord + sub_tx_offset - 0.5);
-    phase = tx_coord + sub_tx_offset - 0.5 - period;
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
-    res.b = texture(tex, (period + 0.5 + offset) * tx_to_uv).b;
+        // Red
+        period = floor(tx_coord - sub_tx_offset - 0.5);
+        phase = tx_coord - sub_tx_offset - 0.5 - period;
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        res.r = texture(tex, (period + 0.5 + offset) * tx_to_uv).r;
+        // Green
+        period = floor(tx_coord - 0.5);
+        phase = tx_coord - 0.5 - period;
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        res.g = texture(tex, (period + 0.5 + offset) * tx_to_uv).g;
+        // Blue
+        period = floor(tx_coord + sub_tx_offset - 0.5);
+        phase = tx_coord + sub_tx_offset - 0.5 - period;
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        res.b = texture(tex, (period + 0.5 + offset) * tx_to_uv).b;
 
-    return res;
-  } else {
-    // The offset for interpolation is a periodic function with
-    // a period length of 1 texel.
-    // The input coordinate is shifted so that the center of the texel
-    // aligns with the start of the period.
-    // First, get the period and phase.
-    period = floor(tx_coord - 0.5);
-    phase = tx_coord - 0.5 - period;
-    // The function starts at 0, then starts transitioning at
-    // 0.5 - 0.5 / pixels_per_texel, then reaches 0.5 at 0.5,
-    // Then reaches 1 at 0.5 + 0.5 / pixels_per_texel.
-    // For sharpness values < 1.0, blend to bilinear filtering.
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        return res;
+    } else {
+        // The offset for interpolation is a periodic function with
+        // a period length of 1 texel.
+        // The input coordinate is shifted so that the center of the texel
+        // aligns with the start of the period.
+        // First, get the period and phase.
+        period = floor(tx_coord - 0.5);
+        phase = tx_coord - 0.5 - period;
+        // The function starts at 0, then starts transitioning at
+        // 0.5 - 0.5 / pixels_per_texel, then reaches 0.5 at 0.5,
+        // Then reaches 1 at 0.5 + 0.5 / pixels_per_texel.
+        // For sharpness values < 1.0, blend to bilinear filtering.
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
 
-    // When the input is in linear color space, we can make use of a single tap
-    // using bilinear interpolation. The offsets are shifted back to the texel
-    // center before sampling.
-    return texture(tex, (period + 0.5 + offset) * tx_to_uv).rgb;
-  }
+        // When the input is in linear color space, we can make use of a single tap
+        // using bilinear interpolation. The offsets are shifted back to the texel
+        // center before sampling.
+        return texture(tex, (period + 0.5 + offset) * tx_to_uv).rgb;
+    }
 }
 
 void main() {
-  FragColor.rgb =
-      pow(pixel_aa(Texture, tx_per_px, tx_to_uv, tx_coord, PIX_AA_SHARP,
-                   PIX_AA_SUBPX > 0.5, int(PIX_AA_SUBPX_ORIENTATION), Rotation),
-          vec3(1.0 / 2.2));
+    FragColor.rgb = pow(pixel_aa(Texture, tx_per_px, tx_to_uv, tx_coord, PIX_AA_SHARP,
+                                 PIX_AA_SUBPX > 0.5, int(PIX_AA_SUBPX_ORIENTATION), Rotation),
+                        vec3(1.0 / 2.2));
 }
 
 #endif

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa_fast.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa_fast.glsl
@@ -6,15 +6,8 @@
 
 #if defined(VERTEX)
 
-#if __VERSION__ >= 130
 #define COMPAT_VARYING out
 #define COMPAT_ATTRIBUTE in
-#define COMPAT_TEXTURE texture
-#else
-#define COMPAT_VARYING varying
-#define COMPAT_ATTRIBUTE attribute
-#define COMPAT_TEXTURE texture2D
-#endif
 
 #ifdef GL_ES
 #define COMPAT_PRECISION mediump
@@ -22,20 +15,18 @@
 #define COMPAT_PRECISION
 #endif
 
-COMPAT_ATTRIBUTE vec4 VertexCoord;
-COMPAT_ATTRIBUTE vec4 TexCoord;
-
-COMPAT_VARYING vec2 tx_coord;
-COMPAT_VARYING vec2 tx_per_px;
-COMPAT_VARYING vec2 px_per_tx;
-COMPAT_VARYING vec2 tx_to_uv;
-
 uniform mat4 MVPMatrix;
-uniform COMPAT_PRECISION int FrameDirection;
-uniform COMPAT_PRECISION int FrameCount;
 uniform COMPAT_PRECISION vec2 OutputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
+
+in vec4 VertexCoord;
+in vec4 TexCoord;
+
+out vec2 tx_coord;
+out vec2 tx_per_px;
+out vec2 px_per_tx;
+out vec2 tx_to_uv;
 
 void main() {
     gl_Position = MVPMatrix * VertexCoord;
@@ -58,25 +49,14 @@ precision mediump float;
 #define COMPAT_PRECISION
 #endif
 
-#if __VERSION__ >= 130
-#define COMPAT_VARYING in
-#define COMPAT_TEXTURE texture
-out COMPAT_PRECISION vec4 FragColor;
-#else
-#define COMPAT_VARYING varying
-#define FragColor gl_FragColor
-#define COMPAT_TEXTURE texture2D
-#endif
-
-uniform COMPAT_PRECISION vec2 OutputSize;
-uniform COMPAT_PRECISION vec2 TextureSize;
-uniform COMPAT_PRECISION vec2 InputSize;
 uniform sampler2D Texture;
 
-COMPAT_VARYING vec2 tx_coord;
-COMPAT_VARYING vec2 tx_per_px;
-COMPAT_VARYING vec2 px_per_tx;
-COMPAT_VARYING vec2 tx_to_uv;
+in vec2 tx_coord;
+in vec2 tx_per_px;
+in vec2 px_per_tx;
+in vec2 tx_to_uv;
+
+out COMPAT_PRECISION vec4 FragColor;
 
 void main() {
     vec2 period;
@@ -84,10 +64,10 @@ void main() {
     period = (period + 0.5) * tx_to_uv;
 
     vec3 samples[4] =
-        vec3[4](COMPAT_TEXTURE(Texture, period).rgb,
-                COMPAT_TEXTURE(Texture, period + vec2(tx_to_uv.x, 0.0)).rgb,
-                COMPAT_TEXTURE(Texture, period + vec2(0.0, tx_to_uv.y)).rgb,
-                COMPAT_TEXTURE(Texture, period + tx_to_uv).rgb);
+        vec3[4](texture(Texture, period).rgb,
+                texture(Texture, period + vec2(tx_to_uv.x, 0.0)).rgb,
+                texture(Texture, period + vec2(0.0, tx_to_uv.y)).rgb,
+                texture(Texture, period + tx_to_uv).rgb);
 
     vec2 t = clamp((phase - 0.5) * px_per_tx + 0.5, 0.0, 1.0);
     vec2 offset = t * t * (3.0 - 2.0 * t);

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa_fast.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa_fast.glsl
@@ -27,10 +27,10 @@ out PREC_MED vec2 px_per_tx;
 out PREC_MED vec2 tx_to_uv;
 
 void main() {
-  gl_Position = MVPMatrix * VertexCoord;
-  tx_coord = TexCoord.xy * TextureSize - 0.5;
-  px_per_tx = OutputSize / InputSize;
-  tx_to_uv = 1.0 / TextureSize;
+    gl_Position = MVPMatrix * VertexCoord;
+    tx_coord = TexCoord.xy * TextureSize - 0.5;
+    px_per_tx = OutputSize / InputSize;
+    tx_to_uv = 1.0 / TextureSize;
 }
 
 #elif defined(FRAGMENT)
@@ -48,14 +48,14 @@ in PREC_MED vec2 tx_to_uv;
 out PREC_LOW vec4 FragColor;
 
 void main() {
-  PREC_MED vec2 period;
-  PREC_MED vec2 phase = modf(tx_coord, period);
+    PREC_MED vec2 period;
+    PREC_MED vec2 phase = modf(tx_coord, period);
 
-  PREC_MED vec2 t = clamp((phase - 0.5) * px_per_tx + 0.5, 0.0, 1.0);
-  PREC_MED vec2 offset = t * t * (3.0 - 2.0 * t);
+    PREC_MED vec2 t = clamp((phase - 0.5) * px_per_tx + 0.5, 0.0, 1.0);
+    PREC_MED vec2 offset = t * t * (3.0 - 2.0 * t);
 
-  PREC_LOW vec3 res = texture(Texture, (period + 0.5 + offset) * tx_to_uv).rgb;
-  FragColor = vec4(sqrt(res), 1.0);
+    PREC_LOW vec3 res = texture(Texture, (period + 0.5 + offset) * tx_to_uv).rgb;
+    FragColor = vec4(sqrt(res), 1.0);
 }
 
 #endif

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa_no_gamma_correction.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa_no_gamma_correction.glsl
@@ -34,10 +34,10 @@ out PREC_MED vec2 tx_per_px;
 out PREC_MED vec2 tx_to_uv;
 
 void main() {
-  gl_Position = MVPMatrix * VertexCoord;
-  tx_coord = TexCoord.xy * TextureSize;
-  tx_per_px = InputSize / OutputSize;
-  tx_to_uv = 1.0 / TextureSize;
+    gl_Position = MVPMatrix * VertexCoord;
+    tx_coord = TexCoord.xy * TextureSize;
+    tx_per_px = InputSize / OutputSize;
+    tx_to_uv = 1.0 / TextureSize;
 }
 
 #elif defined(FRAGMENT)
@@ -64,66 +64,61 @@ in PREC_MED vec2 tx_to_uv;
 
 out PREC_LOW vec4 FragColor;
 
-PREC_MED vec2 slopestep(PREC_MED vec2 edge0, PREC_MED vec2 edge1,
-                        PREC_MED vec2 x, PREC_MED float slope) {
-  x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
-  vec2 s = sign(x - 0.5);
-  vec2 o = (1.0 + s) * 0.5;
-  return o - 0.5 * s * pow(2.0 * (o - s * x), vec2(slope));
+PREC_MED vec2 slopestep(PREC_MED vec2 edge0, PREC_MED vec2 edge1, PREC_MED vec2 x,
+                        PREC_MED float slope) {
+    x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+    vec2 s = sign(x - 0.5);
+    vec2 o = (1.0 + s) * 0.5;
+    return o - 0.5 * s * pow(2.0 * (o - s * x), vec2(slope));
 }
 
-PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px,
-                       PREC_MED vec2 tx_to_uv, PREC_MED vec2 tx_coord,
-                       PREC_MED float sharpness, bool sample_subpx,
-                       PREC_LOW int subpx_orientation,
-                       PREC_LOW int screen_rotation) {
-  PREC_MED float sharpness_upper = min(1.0, sharpness);
-  PREC_MED vec2 sharp_lb = sharpness_upper * (0.5 - 0.5 * tx_per_px);
-  PREC_MED vec2 sharp_ub =
-      1.0 - sharpness_upper * (1.0 - (0.5 + 0.5 * tx_per_px));
-  PREC_MED float sharpness_lower = max(1.0, sharpness);
+PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px, PREC_MED vec2 tx_to_uv,
+                       PREC_MED vec2 tx_coord, PREC_MED float sharpness, bool sample_subpx,
+                       PREC_LOW int subpx_orientation, PREC_LOW int screen_rotation) {
+    PREC_MED float sharpness_upper = min(1.0, sharpness);
+    PREC_MED vec2 sharp_lb = sharpness_upper * (0.5 - 0.5 * tx_per_px);
+    PREC_MED vec2 sharp_ub = 1.0 - sharpness_upper * (1.0 - (0.5 + 0.5 * tx_per_px));
+    PREC_MED float sharpness_lower = max(1.0, sharpness);
 
-  PREC_MED vec2 period, phase, offset;
-  if (sample_subpx) {
-    const vec4 rot_corr = vec4(1.0, 0.0, -1.0, 0.0);
-    PREC_MED vec2 sub_tx_offset =
-        tx_per_px / 3.0 *
-        vec2(rot_corr[(screen_rotation + subpx_orientation) % 4],
-             rot_corr[(screen_rotation + subpx_orientation + 3) % 4]);
+    PREC_MED vec2 period, phase, offset;
+    if (sample_subpx) {
+        const vec4 rot_corr = vec4(1.0, 0.0, -1.0, 0.0);
+        PREC_MED vec2 sub_tx_offset = tx_per_px / 3.0 *
+                                      vec2(rot_corr[(screen_rotation + subpx_orientation) % 4],
+                                           rot_corr[(screen_rotation + subpx_orientation + 3) % 4]);
 
-    PREC_LOW vec3 res;
+        PREC_LOW vec3 res;
 
-    // Red
-    period = floor(tx_coord - sub_tx_offset - 0.5);
-    phase = tx_coord - sub_tx_offset - 0.5 - period;
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
-    res.r = texture(tex, (period + 0.5 + offset) * tx_to_uv).r;
-    // Green
-    period = floor(tx_coord - 0.5);
-    phase = tx_coord - 0.5 - period;
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
-    res.g = texture(tex, (period + 0.5 + offset) * tx_to_uv).g;
-    // Blue
-    period = floor(tx_coord + sub_tx_offset - 0.5);
-    phase = tx_coord + sub_tx_offset - 0.5 - period;
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
-    res.b = texture(tex, (period + 0.5 + offset) * tx_to_uv).b;
+        // Red
+        period = floor(tx_coord - sub_tx_offset - 0.5);
+        phase = tx_coord - sub_tx_offset - 0.5 - period;
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        res.r = texture(tex, (period + 0.5 + offset) * tx_to_uv).r;
+        // Green
+        period = floor(tx_coord - 0.5);
+        phase = tx_coord - 0.5 - period;
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        res.g = texture(tex, (period + 0.5 + offset) * tx_to_uv).g;
+        // Blue
+        period = floor(tx_coord + sub_tx_offset - 0.5);
+        phase = tx_coord + sub_tx_offset - 0.5 - period;
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        res.b = texture(tex, (period + 0.5 + offset) * tx_to_uv).b;
 
-    return res;
-  } else {
-    period = floor(tx_coord - 0.5);
-    phase = tx_coord - 0.5 - period;
+        return res;
+    } else {
+        period = floor(tx_coord - 0.5);
+        phase = tx_coord - 0.5 - period;
 
-    offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
+        offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
 
-    return texture(tex, (period + 0.5 + offset) * tx_to_uv).rgb;
-  }
+        return texture(tex, (period + 0.5 + offset) * tx_to_uv).rgb;
+    }
 }
 
 void main() {
-  FragColor.rgb =
-      pixel_aa(Texture, tx_per_px, tx_to_uv, tx_coord, PIX_AA_SHARP,
-               PIX_AA_SUBPX > 0.5, int(PIX_AA_SUBPX_ORIENTATION), Rotation);
+    FragColor.rgb = pixel_aa(Texture, tx_per_px, tx_to_uv, tx_coord, PIX_AA_SHARP,
+                             PIX_AA_SUBPX > 0.5, int(PIX_AA_SUBPX_ORIENTATION), Rotation);
 }
 
 #endif

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa_no_gamma_correction.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa_no_gamma_correction.glsl
@@ -1,41 +1,6 @@
 #version 130
 
-/*
-    Pixel AA by fishku
-    Copyright (C) 2023-2024
-    Public domain license (CC0)
-
-    Features:
-    - Sharp upscaling with anti-aliasing
-    - Subpixel upscaling
-    - Sharpness can be controlled
-    - Gamma correct blending
-    - Integer scales result in pixel-perfect scaling
-    - Can use bilinear filtering for max. performance
-
-    Inspired by:
-    https://www.shadertoy.com/view/MlB3D3
-    by d7samurai
-    and:
-    https://www.youtube.com/watch?v=d6tp43wZqps
-    by t3ssel8r
-
-    With sharpness = 1.0, using the same gamma-correct blending, and disabling
-    subpixel anti-aliasing, results are identical to the "pixellate" shader.
-
-    Changelog:
-    v1.7: Clean up. Optimize through precision specifiers and separate
-          linearization.
-    v1.6: Add "fast" version for low-end devices.
-    v1.5: Optimize for embedded devices.
-    v1.4: Enable subpixel sampling for all four pixel layout orientations,
-          including rotated screens.
-    v1.3: Account for screen rotation in subpixel sampling.
-    v1.2: Optimize and simplify algorithm. Enable sharpness < 1.0. Fix subpixel
-          sampling bug.
-    v1.1: Better subpixel sampling.
-    v1.0: Initial release.
-*/
+// See main shader file for copyright and other information.
 
 // clang-format off
 #pragma parameter PIX_AA_SETTINGS "=== Pixel AA v1.7 settings ===" 0.0 0.0 1.0 1.0
@@ -176,9 +141,8 @@ PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px,
 
 void main() {
   FragColor.rgb =
-      pow(pixel_aa(Texture, tx_per_px, tx_to_uv, tx_coord, PIX_AA_SHARP,
-                   PIX_AA_SUBPX > 0.5, int(PIX_AA_SUBPX_ORIENTATION), Rotation),
-          vec3(1.0 / 2.2));
+      pixel_aa(Texture, tx_per_px, tx_to_uv, tx_coord, PIX_AA_SHARP,
+               PIX_AA_SUBPX > 0.5, int(PIX_AA_SUBPX_ORIENTATION), Rotation);
 }
 
 #endif

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa_no_gamma_correction.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa_no_gamma_correction.glsl
@@ -64,8 +64,6 @@ in PREC_MED vec2 tx_to_uv;
 
 out PREC_LOW vec4 FragColor;
 
-// Similar to smoothstep, but has a configurable slope at x = 0.5.
-// Original smoothstep has a slope of 1.5 at x = 0.5
 PREC_MED vec2 slopestep(PREC_MED vec2 edge0, PREC_MED vec2 edge1,
                         PREC_MED vec2 x, PREC_MED float slope) {
   x = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
@@ -74,8 +72,6 @@ PREC_MED vec2 slopestep(PREC_MED vec2 edge0, PREC_MED vec2 edge1,
   return o - 0.5 * s * pow(2.0 * (o - s * x), vec2(slope));
 }
 
-// Function to get a pixel value, taking into consideration possible subpixel
-// interpolation.
 PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px,
                        PREC_MED vec2 tx_to_uv, PREC_MED vec2 tx_coord,
                        PREC_MED float sharpness, bool sample_subpx,
@@ -89,10 +85,6 @@ PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px,
 
   PREC_MED vec2 period, phase, offset;
   if (sample_subpx) {
-    // Subpixel sampling: Shift the sampling by 1/3rd of an output pixel for
-    // each subpixel, assuming that the output size is at monitor
-    // resolution.
-    // Compensate for possible rotation of the screen in certain cores.
     const vec4 rot_corr = vec4(1.0, 0.0, -1.0, 0.0);
     PREC_MED vec2 sub_tx_offset =
         tx_per_px / 3.0 *
@@ -119,22 +111,11 @@ PREC_LOW vec3 pixel_aa(PREC_LOW sampler2D tex, PREC_MED vec2 tx_per_px,
 
     return res;
   } else {
-    // The offset for interpolation is a periodic function with
-    // a period length of 1 texel.
-    // The input coordinate is shifted so that the center of the texel
-    // aligns with the start of the period.
-    // First, get the period and phase.
     period = floor(tx_coord - 0.5);
     phase = tx_coord - 0.5 - period;
-    // The function starts at 0, then starts transitioning at
-    // 0.5 - 0.5 / pixels_per_texel, then reaches 0.5 at 0.5,
-    // Then reaches 1 at 0.5 + 0.5 / pixels_per_texel.
-    // For sharpness values < 1.0, blend to bilinear filtering.
+
     offset = slopestep(sharp_lb, sharp_ub, phase, sharpness_lower);
 
-    // When the input is in linear color space, we can make use of a single tap
-    // using bilinear interpolation. The offsets are shifted back to the texel
-    // center before sampling.
     return texture(tex, (period + 0.5 + offset) * tx_to_uv).rgb;
   }
 }

--- a/pixel-art-scaling/shaders/pixel_aa/to_lin.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/to_lin.glsl
@@ -22,8 +22,8 @@ in PREC_MED vec4 TexCoord;
 out PREC_MED vec2 tx_coord;
 
 void main() {
-  gl_Position = MVPMatrix * VertexCoord;
-  tx_coord = TexCoord.xy;
+    gl_Position = MVPMatrix * VertexCoord;
+    tx_coord = TexCoord.xy;
 }
 
 #elif defined(FRAGMENT)
@@ -43,8 +43,8 @@ in PREC_MED vec2 tx_coord;
 out PREC_LOW vec4 FragColor;
 
 void main() {
-  PREC_LOW vec3 s = texture(Texture, tx_coord).rgb;
-  FragColor = vec4(pow(s, vec3(2.2)), 1.0);
+    PREC_LOW vec3 s = texture(Texture, tx_coord).rgb;
+    FragColor = vec4(pow(s, vec3(2.2)), 1.0);
 }
 
 #endif

--- a/pixel-art-scaling/shaders/pixel_aa/to_lin.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/to_lin.glsl
@@ -1,0 +1,50 @@
+#version 130
+
+// See main shader file for copyright and other information.
+
+#ifdef GL_ES
+#define PREC_LOW lowp
+#define PREC_MED mediump
+#define PREC_HIGH highp
+#else
+#define PREC_LOW
+#define PREC_MED
+#define PREC_HIGH
+#endif
+
+#if defined(VERTEX)
+
+uniform PREC_MED mat4 MVPMatrix;
+
+in PREC_MED vec4 VertexCoord;
+in PREC_MED vec4 TexCoord;
+
+out PREC_MED vec2 tx_coord;
+
+void main() {
+  gl_Position = MVPMatrix * VertexCoord;
+  tx_coord = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#endif
+
+uniform PREC_LOW sampler2D Texture;
+
+in PREC_MED vec2 tx_coord;
+
+out PREC_LOW vec4 FragColor;
+
+void main() {
+  PREC_LOW vec3 s = texture(Texture, tx_coord).rgb;
+  FragColor = vec4(pow(s, vec3(2.2)), 1.0);
+}
+
+#endif

--- a/pixel-art-scaling/shaders/pixel_aa/to_lin_fast.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/to_lin_fast.glsl
@@ -22,8 +22,8 @@ in PREC_MED vec4 TexCoord;
 out PREC_MED vec2 tx_coord;
 
 void main() {
-  gl_Position = MVPMatrix * VertexCoord;
-  tx_coord = TexCoord.xy;
+    gl_Position = MVPMatrix * VertexCoord;
+    tx_coord = TexCoord.xy;
 }
 
 #elif defined(FRAGMENT)
@@ -39,8 +39,8 @@ in PREC_MED vec2 tx_coord;
 out PREC_LOW vec4 FragColor;
 
 void main() {
-  PREC_LOW vec3 s = texture(Texture, tx_coord).rgb;
-  FragColor = vec4(s * s, 1.0);
+    PREC_LOW vec3 s = texture(Texture, tx_coord).rgb;
+    FragColor = vec4(s * s, 1.0);
 }
 
 #endif

--- a/pixel-art-scaling/shaders/pixel_aa/to_lin_fast.glsl
+++ b/pixel-art-scaling/shaders/pixel_aa/to_lin_fast.glsl
@@ -1,0 +1,46 @@
+#version 130
+
+// See main shader file for copyright and other information.
+
+#ifdef GL_ES
+#define PREC_LOW lowp
+#define PREC_MED mediump
+#define PREC_HIGH highp
+#else
+#define PREC_LOW
+#define PREC_MED
+#define PREC_HIGH
+#endif
+
+#if defined(VERTEX)
+
+uniform PREC_MED mat4 MVPMatrix;
+
+in PREC_MED vec4 VertexCoord;
+in PREC_MED vec4 TexCoord;
+
+out PREC_MED vec2 tx_coord;
+
+void main() {
+  gl_Position = MVPMatrix * VertexCoord;
+  tx_coord = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform PREC_LOW sampler2D Texture;
+
+in PREC_MED vec2 tx_coord;
+
+out PREC_LOW vec4 FragColor;
+
+void main() {
+  PREC_LOW vec3 s = texture(Texture, tx_coord).rgb;
+  FragColor = vec4(s * s, 1.0);
+}
+
+#endif


### PR DESCRIPTION
Clean up, heavily optimize.

On low-end RK3326 device, improvements are as follows:
pixel_aa.glslp:
Improve from 23 to 10 ms with default params (~80% improvement)
31 -> 21 ms with sub-pixel sampling (~45% improvement)

pixel_aa_fast.glslp:
9.2 -> 8.5 ms (~30% improvement)