### PR TITLE
Update lcd*x and authentic_gbc to use OriginalSize

### DIFF
--- a/handheld/shaders/authentic_gbc/authentic_gbc.glsl
+++ b/handheld/shaders/authentic_gbc/authentic_gbc.glsl
@@ -1,7 +1,7 @@
 #version 130
 
 /*
-    Authentic GBC v1.0 by fishku
+    Authentic GBC by fishku
     Copyright (C) 2024
     Public domain license (CC0)
 
@@ -15,12 +15,13 @@
    https://www.reddit.com/r/AnaloguePocket/comments/1azaxgd/ive_made_some_improvements_to_my_analogue_pocket/
 
     Changelog:
+    v1.1: Use OriginalSize instead of SourceSize to better work with combined presets.
     v1.0: Initial release, ported from Slang.
 */
 
 // clang-format off
-#pragma parameter AUTH_GBC_SETTINGS "=== Authentic GBC v1.0 settings ===" 0.0 0.0 1.0 1.0
-#pragma parameter AUTH_GBC_BRIG "Overbrighten" 0.0 -0.1 1.0 0.05
+#pragma parameter AUTH_GBC_SETTINGS "=== Authentic GBC v1.1 settings ===" 0.0 0.0 1.0 1.0
+#pragma parameter AUTH_GBC_BRIG "Overbrighten" 0.15 -0.1 1.0 0.05
 // clang-format on
 
 #if defined(VERTEX)
@@ -40,15 +41,16 @@
 #endif
 
 uniform mat4 MVPMatrix;
-uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 OrigInputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION vec2 OutputSize;
 
 COMPAT_ATTRIBUTE vec4 VertexCoord;
 COMPAT_ATTRIBUTE vec4 TexCoord;
 
 COMPAT_VARYING vec4 px_rect;
-COMPAT_VARYING vec2 inv_texture_size;
+COMPAT_VARYING vec2 tx_to_uv;
 COMPAT_VARYING vec2 tx_coord;
 COMPAT_VARYING vec2 tx_to_px;
 COMPAT_VARYING vec2 subpx_size;
@@ -61,21 +63,33 @@ uniform COMPAT_PRECISION float AUTH_GBC_BRIG;
 #define AUTH_GBC_BRIG 0.0
 #endif
 
+// As determined by counting pixels on a photo.
 const vec2 subpx_ratio = vec2(0.296, 0.910);
 const vec2 notch_ratio = vec2(0.115, 0.166);
 
 void main() {
     gl_Position = MVPMatrix * VertexCoord;
 
-    inv_texture_size = 1.0 / TextureSize;
+    // Given coordinates in source texel coord. system, multiply by this to get UV in
+    // [0, 1] to sample from source.
+    tx_to_uv = 1.0 / OrigInputSize * InputSize / TextureSize;
 
-    vec2 px_coord = OutputSize * TexCoord.xy * TextureSize / InputSize;
+    // Fragment coordinates in output pixel system in [0, output size]
+    vec2 px_coord = TexCoord.xy * OutputSize * TextureSize / InputSize;
+    // Upper left and bottom right corner of square surrounding the output fragment
     px_rect = vec4(px_coord - 0.5, px_coord + 0.5);
-    tx_coord = TexCoord.xy * TextureSize;
-    tx_to_px = OutputSize / InputSize;
-    subpx_size =
-        tx_to_px * mix(subpx_ratio, vec2(2.0 / 3.0, 1.0), AUTH_GBC_BRIG);
+    // Texel coordinates in source texel system in [0, original input size]
+    tx_coord = TexCoord.xy * OrigInputSize * TextureSize / InputSize;
+    // Size of one output pixel in source texel coordinates (inverse of texel size in pixels).
+    // Multiply a texel coordinate by this to get pixel coordinates
+    tx_to_px = OutputSize / OrigInputSize;
+
+    // Precompute some sizes that are common for all sampled subpixels.
+    // Size in pixels of a single R/G/B subpixel
+    subpx_size = tx_to_px * mix(subpx_ratio, vec2(2.0 / 3.0, 1.0), AUTH_GBC_BRIG);
+    // Size in pixels of the "notch" present in the corner of each subpixel
     notch_size = tx_to_px * mix(notch_ratio, vec2(0.0), AUTH_GBC_BRIG);
+    // Y coordinate in output pixel system of the origin of the subpixel, centered vertically
     subpx_orig_y = (tx_to_px.y - subpx_size.y) * 0.5;
 }
 
@@ -107,7 +121,7 @@ uniform COMPAT_PRECISION vec2 TextureSize;
 uniform sampler2D Texture;
 
 COMPAT_VARYING vec4 px_rect;
-COMPAT_VARYING vec2 inv_texture_size;
+COMPAT_VARYING vec2 tx_to_uv;
 COMPAT_VARYING vec2 tx_coord;
 COMPAT_VARYING vec2 tx_to_px;
 COMPAT_VARYING vec2 subpx_size;
@@ -123,38 +137,32 @@ float rect_coverage(vec4 rect) {
 
 float subpx_coverage(vec2 subpx_orig) {
     return rect_coverage(vec4(subpx_orig, subpx_orig + subpx_size)) -
-           rect_coverage(
-               vec4(subpx_orig.x, subpx_orig.y + subpx_size.y - notch_size.y,
-                    subpx_orig.x + notch_size.x, subpx_orig.y + subpx_size.y));
+           rect_coverage(vec4(subpx_orig.x, subpx_orig.y + subpx_size.y - notch_size.y,
+                              subpx_orig.x + notch_size.x, subpx_orig.y + subpx_size.y));
 }
 
 vec3 pixel_color(vec2 px_orig) {
     return vec3(
-        subpx_coverage(px_orig + vec2(tx_to_px.x / 6.0 - subpx_size.x * 0.5,
-                                      subpx_orig_y)),
-        subpx_coverage(px_orig + vec2(tx_to_px.x / 2.0 - subpx_size.x * 0.5,
-                                      subpx_orig_y)),
-        subpx_coverage(
-            px_orig +
-            vec2(5.0 * tx_to_px.x / 6.0 - subpx_size.x * 0.5, subpx_orig_y)));
+        subpx_coverage(px_orig + vec2(tx_to_px.x / 6.0 - subpx_size.x * 0.5, subpx_orig_y)),
+        subpx_coverage(px_orig + vec2(tx_to_px.x / 2.0 - subpx_size.x * 0.5, subpx_orig_y)),
+        subpx_coverage(px_orig + vec2(5.0 * tx_to_px.x / 6.0 - subpx_size.x * 0.5, subpx_orig_y)));
 }
 
 void main() {
-    // Figure out 4 nearest texels in source texture
+    // Figure out 4 nearest texels in source texture.
+    // All coordinates in source texel coord. system
     vec2 tx_coord_i;
     vec2 tx_coord_f = modf(tx_coord, tx_coord_i);
     vec2 tx_coord_off = step(vec2(0.5), tx_coord_f) * 2.0 - 1.0;
-    vec2 tx_origins[4] = vec2[](
-        tx_coord_i, tx_coord_i + vec2(tx_coord_off.x, 0.0),
-        tx_coord_i + vec2(0.0, tx_coord_off.y), tx_coord_i + tx_coord_off);
+    vec2 tx_origins[4] = vec2[](tx_coord_i, tx_coord_i + vec2(tx_coord_off.x, 0.0),
+                                tx_coord_i + vec2(0.0, tx_coord_off.y), tx_coord_i + tx_coord_off);
 
     // Sample.
     // Apply square for fast "gamma correction".
-    vec3 samples[4] =
-        vec3[](texture(Texture, (tx_origins[0] + 0.5) * inv_texture_size).rgb,
-               texture(Texture, (tx_origins[1] + 0.5) * inv_texture_size).rgb,
-               texture(Texture, (tx_origins[2] + 0.5) * inv_texture_size).rgb,
-               texture(Texture, (tx_origins[3] + 0.5) * inv_texture_size).rgb);
+    vec3 samples[4] = vec3[](texture(Texture, (tx_origins[0] + 0.5) * tx_to_uv).rgb,
+                             texture(Texture, (tx_origins[1] + 0.5) * tx_to_uv).rgb,
+                             texture(Texture, (tx_origins[2] + 0.5) * tx_to_uv).rgb,
+                             texture(Texture, (tx_origins[3] + 0.5) * tx_to_uv).rgb);
     samples[0] *= samples[0];
     samples[1] *= samples[1];
     samples[2] *= samples[2];

--- a/handheld/shaders/lcd1x.glsl
+++ b/handheld/shaders/lcd1x.glsl
@@ -80,9 +80,10 @@ precision highp int;
 
 uniform COMPAT_PRECISION int FrameDirection;
 uniform COMPAT_PRECISION int FrameCount;
-uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 OrigInputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION vec2 OutputSize;
 uniform sampler2D Texture;
 COMPAT_VARYING vec4 TEX0;
 
@@ -106,7 +107,8 @@ void main()
    // Generate LCD grid effect
    // > Note the 0.25 pixel offset -> required to ensure that
    //   scanlines occur *between* pixels
-   COMPAT_PRECISION vec2 angle = 2.0 * PI * ((TEX0.xy * TextureSize.xy) - 0.25);
+   COMPAT_PRECISION vec2 angle =
+      2.0 * PI * ((TEX0.xy * OrigInputSize * TextureSize / InputSize) - 0.25);
 
    COMPAT_PRECISION float yfactor = (BRIGHTEN_SCANLINES + sin(angle.y)) / (BRIGHTEN_SCANLINES + 1.0);
    COMPAT_PRECISION float xfactor = (BRIGHTEN_LCD + sin(angle.x)) / (BRIGHTEN_LCD + 1.0);

--- a/handheld/shaders/lcd1x_nds.glsl
+++ b/handheld/shaders/lcd1x_nds.glsl
@@ -58,7 +58,7 @@ uniform COMPAT_PRECISION int FrameDirection;
 uniform COMPAT_PRECISION int FrameCount;
 uniform COMPAT_PRECISION vec2 OutputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
-uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION vec2 OrigInputSize;
 
 /*
    VERTEX_SHADER
@@ -69,7 +69,7 @@ void main()
    gl_Position = MVPMatrix * VertexCoord;
    // Cache divisions here for efficiency...
    // (Assuming it is more efficient...?)
-   InvInputHeight = 1.0 / InputSize.y;
+   InvInputHeight = 1.0 / OrigInputSize.y;
 }
 
 #elif defined(FRAGMENT)
@@ -94,9 +94,10 @@ precision highp int;
 
 uniform COMPAT_PRECISION int FrameDirection;
 uniform COMPAT_PRECISION int FrameCount;
-uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 OrigInputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION vec2 OutputSize;
 uniform sampler2D Texture;
 COMPAT_VARYING vec4 TEX0;
 varying COMPAT_PRECISION float InvInputHeight;
@@ -138,7 +139,10 @@ void main()
    //   scanlines occur *between* pixels
    // > Divide pixel coordinate by current scale factor
    //   (input_video_height / nds_screen_height)
-   COMPAT_PRECISION vec2 angle = 2.0 * PI * (((TEX0.xy * TextureSize.xy) * NDS_SCREEN_HEIGHT * InvInputHeight) - 0.25);
+   COMPAT_PRECISION vec2 angle = 2.0 * PI *
+                              (((TEX0.xy * OrigInputSize * TextureSize / InputSize) *
+                                NDS_SCREEN_HEIGHT * InvInputHeight) -
+                               0.25);
 
    COMPAT_PRECISION float yfactor = (BRIGHTEN_SCANLINES + sin(angle.y)) / (BRIGHTEN_SCANLINES + 1.0);
    COMPAT_PRECISION float xfactor = (BRIGHTEN_LCD + sin(angle.x)) / (BRIGHTEN_LCD + 1.0);

--- a/handheld/shaders/lcd1x_psp.glsl
+++ b/handheld/shaders/lcd1x_psp.glsl
@@ -58,7 +58,7 @@ uniform COMPAT_PRECISION int FrameDirection;
 uniform COMPAT_PRECISION int FrameCount;
 uniform COMPAT_PRECISION vec2 OutputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
-uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION vec2 OrigInputSize;
 
 /*
    VERTEX_SHADER
@@ -69,7 +69,7 @@ void main()
    gl_Position = MVPMatrix * VertexCoord;
    // Cache divisions here for efficiency...
    // (Assuming it is more efficient...?)
-   InvInputHeight = 1.0 / InputSize.y;
+   InvInputHeight = 1.0 / OrigInputSize.y;
 }
 
 #elif defined(FRAGMENT)
@@ -94,9 +94,10 @@ precision highp int;
 
 uniform COMPAT_PRECISION int FrameDirection;
 uniform COMPAT_PRECISION int FrameCount;
-uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 OrigInputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION vec2 OutputSize;
 uniform sampler2D Texture;
 COMPAT_VARYING vec4 TEX0;
 varying COMPAT_PRECISION float InvInputHeight;
@@ -137,7 +138,10 @@ void main()
    //   scanlines occur *between* pixels
    // > Divide pixel coordinate by current scale factor
    //   (input_video_height / psp_screen_height)
-   COMPAT_PRECISION vec2 angle = 2.0 * PI * (((TEX0.xy * TextureSize.xy) * PSP_SCREEN_HEIGHT * InvInputHeight) - 0.25);
+   COMPAT_PRECISION vec2 angle = 2.0 * PI *
+                                 (((TEX0.xy * OrigInputSize * TextureSize / InputSize) *
+                                   PSP_SCREEN_HEIGHT * InvInputHeight) -
+                                  0.25);
 
    COMPAT_PRECISION float yfactor = (BRIGHTEN_SCANLINES + sin(angle.y)) / (BRIGHTEN_SCANLINES + 1.0);
    COMPAT_PRECISION float xfactor = (BRIGHTEN_LCD + sin(angle.x)) / (BRIGHTEN_LCD + 1.0);

--- a/handheld/shaders/lcd3x.glsl
+++ b/handheld/shaders/lcd3x.glsl
@@ -32,11 +32,6 @@ COMPAT_VARYING vec4 COL0;
 COMPAT_VARYING vec4 TEX0;
 
 uniform mat4 MVPMatrix;
-uniform COMPAT_PRECISION int FrameDirection;
-uniform COMPAT_PRECISION int FrameCount;
-uniform COMPAT_PRECISION vec2 OutputSize;
-uniform COMPAT_PRECISION vec2 TextureSize;
-uniform COMPAT_PRECISION vec2 InputSize;
 
 void main()
 {
@@ -70,9 +65,10 @@ precision mediump float;
 
 uniform COMPAT_PRECISION int FrameDirection;
 uniform COMPAT_PRECISION int FrameCount;
-uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 OrigInputSize;
 uniform COMPAT_PRECISION vec2 TextureSize;
 uniform COMPAT_PRECISION vec2 InputSize;
+uniform COMPAT_PRECISION vec2 OutputSize;
 uniform sampler2D Texture;
 COMPAT_VARYING vec4 TEX0;
 
@@ -80,7 +76,6 @@ COMPAT_VARYING vec4 TEX0;
 #define Source Texture
 #define vTexCoord TEX0.xy
 
-#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
 #define outsize vec4(OutputSize, 1.0 / OutputSize)
 
 #ifdef PARAMETER_UNIFORM
@@ -96,10 +91,10 @@ const vec3 offsets = vec3(3.141592654) * vec3(1.0/2.0,1.0/2.0 - 2.0/3.0,1.0/2.0-
 
 void main()
 {
-    vec2 omega = vec2(3.141592654) * vec2(2.0) * SourceSize.xy;
+    vec2 omega = vec2(3.141592654) * vec2(2.0) * OrigInputSize;
     vec3 res = COMPAT_TEXTURE(Source, vTexCoord).xyz;
 
-    vec2 angle = vTexCoord * omega;
+    vec2 angle = vTexCoord * TextureSize / InputSize * omega;
 	
     float yfactor = (brighten_scanlines + sin(angle.y)) / (brighten_scanlines + 1.0);
     vec3 xfactors = (brighten_lcd + sin(angle.x + offsets)) / (brighten_lcd + 1.0);


### PR DESCRIPTION
This makes these presets work better when combining presets with append / prepend.

Same changes as in https://github.com/libretro/slang-shaders/pull/665, slightly more complicated due to POT textures as usual. :) 