### PR TITLE
Add CUT upscaling shaders.

### DIFF
--- a/cut/cut1.glslp
+++ b/cut/cut1.glslp
@@ -1,0 +1,6 @@
+shaders = 1
+
+shader0 = shaders/cut1/cut1.glsl
+filter_linear0 = false
+scale_type0 = viewport
+scale0 = 1.0

--- a/cut/cut2.glslp
+++ b/cut/cut2.glslp
@@ -1,0 +1,11 @@
+shaders = 2
+
+shader0 = shaders/cut2/cut2-pass0.glsl
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = shaders/cut2/cut2-pass1.glsl
+filter_linear1 = false
+scale_type1 = viewport
+scale1 = 1.0

--- a/cut/cut3.glslp
+++ b/cut/cut3.glslp
@@ -1,0 +1,16 @@
+shaders = 3
+
+shader0 = shaders/cut3/cut3-pass0.glsl
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = shaders/cut3/cut3-pass1.glsl
+filter_linear1 = false
+scale_type1 = source
+scale1 = 1.0
+
+shader2 = shaders/cut3/cut3-pass2.glsl
+filter_linear2 = false
+scale_type2 = viewport
+scale1 = 1.0

--- a/cut/shaders/cut1/cut1.glsl
+++ b/cut/shaders/cut1/cut1.glsl
@@ -1,0 +1,270 @@
+/*
+ * Cheap Upscaling Triangulation
+ *
+ * Copyright (c) Filippo Scognamiglio 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma parameter BLEND_MIN_CONTRAST_EDGE "Min contrast edge strength" 0.0 0.0 1.0
+#pragma parameter BLEND_MAX_CONTRAST_EDGE "Max contrast edge strength" 0.5 0.0 1.0
+#pragma parameter BLEND_MIN_SHARPNESS "Min sharpness" 0.0 0.0 1.0
+#pragma parameter BLEND_MAX_SHARPNESS "Max sharpness" 0.5 0.0 1.0
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 screenCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    COMPAT_PRECISION_HIGHP vec2 coords = TexCoord.xy * 1.00001;
+    screenCoords = coords * TextureSize - vec2(0.5);
+    c05 = (screenCoords + vec2(+0.0, +0.0)) / TextureSize;
+    c06 = (screenCoords + vec2(+1.0, +0.0)) / TextureSize;
+    c09 = (screenCoords + vec2(+0.0, +1.0)) / TextureSize;
+    c10 = (screenCoords + vec2(+1.0, +1.0)) / TextureSize;
+    gl_Position = MVPMatrix * VertexCoord;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#define EPSILON 0.02
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 screenCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float BLEND_MIN_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MAX_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MIN_SHARPNESS;
+uniform COMPAT_PRECISION float BLEND_MAX_SHARPNESS;
+uniform COMPAT_PRECISION float EDGE_MIN_VALUE;
+#else
+#define BLEND_MIN_CONTRAST_EDGE 0.0
+#define BLEND_MAX_CONTRAST_EDGE 0.5
+#define BLEND_MIN_SHARPNESS 0.0
+#define BLEND_MAX_SHARPNESS 0.50
+#define EDGE_MIN_VALUE 0.05
+#endif
+
+#define USE_DYNAMIC_BLEND 1
+#define STATIC_BLEND_SHARPNESS 1.0
+#define EDGE_USE_FAST_LUMA 0
+
+COMPAT_PRECISION_LOWP float luma(COMPAT_PRECISION_LOWP vec3 v) {
+#if EDGE_USE_FAST_LUMA
+    COMPAT_PRECISION_LOWP float result = v.g;
+#else
+    COMPAT_PRECISION_LOWP float result = dot(v, vec3(0.299, 0.587, 0.114));
+#endif
+  return result;
+}
+
+struct Pixels {
+    COMPAT_PRECISION_LOWP vec3 p0;
+    COMPAT_PRECISION_LOWP vec3 p1;
+    COMPAT_PRECISION_LOWP vec3 p2;
+    COMPAT_PRECISION_LOWP vec3 p3;
+};
+
+struct Pattern {
+    Pixels pixels;
+    bool triangle;
+    COMPAT_PRECISION_LOWP vec2 coords;
+};
+
+COMPAT_PRECISION_LOWP vec3 triangle(COMPAT_PRECISION_LOWP vec2 pxCoords) {
+    COMPAT_PRECISION_LOWP vec3 ws = vec3(0.0);
+    ws.x = pxCoords.y - pxCoords.x;
+    ws.y = 1.0 - ws.x;
+    ws.z = (pxCoords.y - ws.x) / (ws.y + EPSILON);
+    return ws;
+}
+
+COMPAT_PRECISION_LOWP vec3 quad(COMPAT_PRECISION_LOWP vec2 pxCoords) {
+    return vec3(pxCoords.x, pxCoords.x, pxCoords.y);
+}
+
+COMPAT_PRECISION_LOWP float linearStep(COMPAT_PRECISION_LOWP float edge0, COMPAT_PRECISION_LOWP float edge1, COMPAT_PRECISION_LOWP float t) {
+    return clamp((t - edge0) / (edge1 - edge0 + EPSILON), 0.0, 1.0);
+}
+
+COMPAT_PRECISION_LOWP float sharpness(COMPAT_PRECISION_LOWP float l1, COMPAT_PRECISION_LOWP float l2) {
+#if USE_DYNAMIC_BLEND
+    COMPAT_PRECISION_LOWP float lumaDiff = abs(l1 - l2);
+    COMPAT_PRECISION_LOWP float contrast = linearStep(BLEND_MIN_CONTRAST_EDGE, BLEND_MAX_CONTRAST_EDGE, lumaDiff);
+    COMPAT_PRECISION_LOWP float result = mix(BLEND_MIN_SHARPNESS * 0.5, BLEND_MAX_SHARPNESS * 0.5, contrast);
+#else
+    COMPAT_PRECISION_LOWP float result = STATIC_BLEND_SHARPNESS * 0.5;
+#endif
+  return result;
+}
+
+bool hasDiagonal(COMPAT_PRECISION_LOWP float a, COMPAT_PRECISION_LOWP float b, COMPAT_PRECISION_LOWP float c, COMPAT_PRECISION_LOWP float d) {
+    return distance(a, d) * 2.0 + EDGE_MIN_VALUE < distance(b, c);
+}
+
+COMPAT_PRECISION_LOWP vec3 blend(COMPAT_PRECISION_LOWP vec3 a, COMPAT_PRECISION_LOWP vec3 b, COMPAT_PRECISION_LOWP float t) {
+    COMPAT_PRECISION_LOWP float sharpness = sharpness(luma(a), luma(b));
+    return mix(a, b, linearStep(sharpness, 1.0 - sharpness, t));
+}
+
+Pattern pattern0(Pixels pixels, COMPAT_PRECISION_LOWP vec2 pxCoords) {
+    return Pattern(pixels, false, pxCoords);
+}
+
+Pattern pattern1(Pixels pixels, COMPAT_PRECISION_LOWP vec2 pxCoords) {
+    Pattern result;
+    if (pxCoords.y > pxCoords.x) {
+        result.pixels = Pixels(pixels.p0, pixels.p2, pixels.p2, pixels.p3);
+        result.coords = vec2(pxCoords.x, pxCoords.y);
+    } else {
+        result.pixels = Pixels(pixels.p0, pixels.p1, pixels.p1, pixels.p3);
+        result.coords = vec2(pxCoords.y, pxCoords.x);
+    }
+    result.triangle = true;
+    return result;
+}
+
+void main() {
+    COMPAT_PRECISION_LOWP vec3 t05 = COMPAT_TEXTURE(Texture, c05).rgb;
+    COMPAT_PRECISION_LOWP vec3 t06 = COMPAT_TEXTURE(Texture, c06).rgb;
+    COMPAT_PRECISION_LOWP vec3 t09 = COMPAT_TEXTURE(Texture, c09).rgb;
+    COMPAT_PRECISION_LOWP vec3 t10 = COMPAT_TEXTURE(Texture, c10).rgb;
+
+    COMPAT_PRECISION_LOWP float l05 = luma(t05);
+    COMPAT_PRECISION_LOWP float l06 = luma(t06);
+    COMPAT_PRECISION_LOWP float l09 = luma(t09);
+    COMPAT_PRECISION_LOWP float l10 = luma(t10);
+
+    Pixels pixels = Pixels(t05, t06, t09, t10);
+
+    bool d05_10 = hasDiagonal(l05, l06, l09, l10);
+    bool d06_09 = hasDiagonal(l06, l05, l10, l09);
+
+    COMPAT_PRECISION_LOWP vec2 pxCoords = fract(screenCoords);
+
+    if (d06_09) {
+        pixels = Pixels(pixels.p1, pixels.p0, pixels.p3, pixels.p2);
+        pxCoords.x = 1.0 - pxCoords.x;
+    }
+
+    Pattern pattern;
+
+    if (d05_10 || d06_09) {
+        pattern = pattern1(pixels, pxCoords);
+    } else {
+        pattern = pattern0(pixels, pxCoords);
+    }
+
+    COMPAT_PRECISION_LOWP vec3 weights = pattern.triangle ? triangle(pattern.coords) : quad(pattern.coords);
+
+    COMPAT_PRECISION_LOWP vec3 final = blend(
+        blend(pattern.pixels.p0, pattern.pixels.p1, weights.x),
+        blend(pattern.pixels.p2, pattern.pixels.p3, weights.y),
+        weights.z
+    );
+
+    FragColor = vec4(final, 1.0);
+}
+#endif

--- a/cut/shaders/cut2/cut2-pass0.glsl
+++ b/cut/shaders/cut2/cut2-pass0.glsl
@@ -1,0 +1,346 @@
+/*
+ * Cheap Upscaling Triangulation
+ *
+ * Copyright (c) Filippo Scognamiglio 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma parameter BLEND_MIN_CONTRAST_EDGE "Min contrast edge strength" 0.0 0.0 1.0
+#pragma parameter BLEND_MAX_CONTRAST_EDGE "Max contrast edge strength" 0.5 0.0 1.0
+#pragma parameter BLEND_MIN_SHARPNESS "Min sharpness" 0.0 0.0 1.0
+#pragma parameter BLEND_MAX_SHARPNESS "Max sharpness" 0.7 0.0 1.0
+#pragma parameter SOFT_EDGES_SHARPENING_AMOUNT "Soft edges sharpening" 1.0 0.0 1.0
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c01;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c02;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c04;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c07;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c08;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c11;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c13;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c14;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    COMPAT_PRECISION_HIGHP vec2 coords = TexCoord.xy * 1.00001;
+    COMPAT_PRECISION_HIGHP vec2 screenCoords = coords * TextureSize - vec2(0.5);
+    c01 = (screenCoords + vec2(+0.0, -1.0)) / TextureSize;
+    c02 = (screenCoords + vec2(+1.0, -1.0)) / TextureSize;
+    c04 = (screenCoords + vec2(-1.0, +0.0)) / TextureSize;
+    c05 = (screenCoords + vec2(+0.0, +0.0)) / TextureSize;
+    c06 = (screenCoords + vec2(+1.0, +0.0)) / TextureSize;
+    c07 = (screenCoords + vec2(+2.0, +0.0)) / TextureSize;
+    c08 = (screenCoords + vec2(-1.0, +1.0)) / TextureSize;
+    c09 = (screenCoords + vec2(+0.0, +1.0)) / TextureSize;
+    c10 = (screenCoords + vec2(+1.0, +1.0)) / TextureSize;
+    c11 = (screenCoords + vec2(+2.0, +1.0)) / TextureSize;
+    c13 = (screenCoords + vec2(+0.0, +2.0)) / TextureSize;
+    c14 = (screenCoords + vec2(+1.0, +2.0)) / TextureSize;
+    gl_Position = MVPMatrix * VertexCoord;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#define EPSILON 0.02
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c01;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c02;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c04;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c07;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c08;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c11;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c13;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c14;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float BLEND_MIN_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MAX_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MIN_SHARPNESS;
+uniform COMPAT_PRECISION float BLEND_MAX_SHARPNESS;
+uniform COMPAT_PRECISION float SOFT_EDGES_SHARPENING_AMOUNT;
+#else
+#define BLEND_MIN_CONTRAST_EDGE 0.0
+#define BLEND_MAX_CONTRAST_EDGE 0.5
+#define BLEND_MIN_SHARPNESS 0.0
+#define BLEND_MAX_SHARPNESS 0.7
+#define SOFT_EDGES_SHARPENING_AMOUNT 1.0
+#endif
+
+#define USE_DYNAMIC_BLEND 1
+#define STATIC_BLEND_SHARPNESS 0.0
+#define EDGE_USE_FAST_LUMA 0
+#define SOFT_EDGES_SHARPENING 1
+#define EDGE_MIN_VALUE 0.025
+
+COMPAT_PRECISION_LOWP float maxOf(COMPAT_PRECISION_LOWP vec4 values) {
+    return max(max(values.x, values.y), max(values.z, values.w));
+}
+
+COMPAT_PRECISION_LOWP float minOf(COMPAT_PRECISION_LOWP vec4 values) {
+    return min(min(values.x, values.y), min(values.z, values.w));
+}
+
+COMPAT_PRECISION_LOWP float luma(COMPAT_PRECISION_LOWP vec3 v) {
+#if EDGE_USE_FAST_LUMA
+    COMPAT_PRECISION_LOWP float result = v.g;
+#else
+    COMPAT_PRECISION_LOWP float result = dot(v, vec3(0.299, 0.587, 0.114));
+#endif
+  return result;
+}
+
+COMPAT_PRECISION_LOWP float quickPackBools2(bvec2 values) {
+    return dot(vec2(values), vec2(0.5, 0.25));
+}
+
+COMPAT_PRECISION_LOWP float quickPackFloats2(COMPAT_PRECISION_LOWP vec2 values) {
+    return dot(floor(values * vec2(12.0) + vec2(0.5)), vec2(0.0625, 0.00390625));
+}
+
+struct Quad {
+    COMPAT_PRECISION_LOWP vec4 scores;
+};
+
+Quad quad(COMPAT_PRECISION_LOWP vec4 values) {
+    COMPAT_PRECISION_LOWP vec4 edges = values.xyzx - values.ywwz;
+
+    Quad result;
+    result.scores = vec4(
+    abs(edges.x + edges.z),
+    abs(edges.w + edges.y),
+    max(abs(edges.x - edges.y), abs(edges.w - edges.z)),
+    max(abs(edges.x + edges.w), abs(edges.y + edges.z))
+    );
+    return result;
+}
+
+COMPAT_PRECISION_LOWP int computePattern(COMPAT_PRECISION_LOWP vec4 scores, COMPAT_PRECISION_LOWP vec4 neighborsScores) {
+    bool isDiagonal = max(scores.z, scores.w) > max(scores.x, scores.y);
+
+    scores += 0.25 * neighborsScores;
+
+    COMPAT_PRECISION_LOWP int result = 0;
+    if (!isDiagonal) {
+        if (scores.x > scores.y + EDGE_MIN_VALUE) {
+            result = 1;
+        } else if (scores.y > scores.x + EDGE_MIN_VALUE) {
+            result = 2;
+        }
+    } else {
+        if (scores.z > scores.w + EDGE_MIN_VALUE) {
+            result = 3;
+        } else if (scores.w > scores.z + EDGE_MIN_VALUE) {
+            result = 4;
+        }
+    }
+
+    return result;
+}
+
+COMPAT_PRECISION_LOWP int findPattern(Quad quad) {
+    return computePattern(quad.scores, vec4(0.0));
+}
+
+COMPAT_PRECISION_LOWP int findPattern(Quad quads[5]) {
+    COMPAT_PRECISION_LOWP vec4 adjustments = vec4(0.0);
+    adjustments += quads[1].scores;
+    adjustments += quads[2].scores;
+    adjustments += quads[3].scores;
+    adjustments += quads[4].scores;
+    return computePattern(quads[0].scores, adjustments);
+}
+
+COMPAT_PRECISION_LOWP float softEdgeWeight(COMPAT_PRECISION_LOWP float a, COMPAT_PRECISION_LOWP float b, COMPAT_PRECISION_LOWP float c, COMPAT_PRECISION_LOWP float d) {
+    COMPAT_PRECISION_LOWP float result = 0.0;
+    result += clamp((abs(b - c) / (abs(a - c) + EPSILON)), 0.0, 1.0);
+    result -= clamp((abs(c - b) / (abs(b - d) + EPSILON)), 0.0, 1.0);
+    return clamp(2.0 * result, -1.0, 1.0);
+}
+
+COMPAT_PRECISION_LOWP float hardEdgeWeight(COMPAT_PRECISION_LOWP int cp, COMPAT_PRECISION_LOWP int np, COMPAT_PRECISION_LOWP int vertical, COMPAT_PRECISION_LOWP int positiveDiagonal, COMPAT_PRECISION_LOWP int negativeDiagonal) {
+    COMPAT_PRECISION_LOWP float result = 0.0;
+    if ((cp == vertical && np == positiveDiagonal) || (np == vertical && cp == negativeDiagonal)) {
+        result = 0.5;
+    } else if ((cp == vertical && np == negativeDiagonal) || (np == vertical && cp == positiveDiagonal)) {
+        result = -0.5;
+    }
+    return result;
+}
+
+void main() {
+    COMPAT_PRECISION_LOWP vec3 t01 = COMPAT_TEXTURE(Texture, c01).rgb;
+    COMPAT_PRECISION_LOWP vec3 t02 = COMPAT_TEXTURE(Texture, c02).rgb;
+    COMPAT_PRECISION_LOWP vec3 t04 = COMPAT_TEXTURE(Texture, c04).rgb;
+    COMPAT_PRECISION_LOWP vec3 t05 = COMPAT_TEXTURE(Texture, c05).rgb;
+    COMPAT_PRECISION_LOWP vec3 t06 = COMPAT_TEXTURE(Texture, c06).rgb;
+    COMPAT_PRECISION_LOWP vec3 t07 = COMPAT_TEXTURE(Texture, c07).rgb;
+    COMPAT_PRECISION_LOWP vec3 t08 = COMPAT_TEXTURE(Texture, c08).rgb;
+    COMPAT_PRECISION_LOWP vec3 t09 = COMPAT_TEXTURE(Texture, c09).rgb;
+    COMPAT_PRECISION_LOWP vec3 t10 = COMPAT_TEXTURE(Texture, c10).rgb;
+    COMPAT_PRECISION_LOWP vec3 t11 = COMPAT_TEXTURE(Texture, c11).rgb;
+    COMPAT_PRECISION_LOWP vec3 t13 = COMPAT_TEXTURE(Texture, c13).rgb;
+    COMPAT_PRECISION_LOWP vec3 t14 = COMPAT_TEXTURE(Texture, c14).rgb;
+
+    COMPAT_PRECISION_LOWP float l01 = luma(t01);
+    COMPAT_PRECISION_LOWP float l02 = luma(t02);
+    COMPAT_PRECISION_LOWP float l04 = luma(t04);
+    COMPAT_PRECISION_LOWP float l05 = luma(t05);
+    COMPAT_PRECISION_LOWP float l06 = luma(t06);
+    COMPAT_PRECISION_LOWP float l07 = luma(t07);
+    COMPAT_PRECISION_LOWP float l08 = luma(t08);
+    COMPAT_PRECISION_LOWP float l09 = luma(t09);
+    COMPAT_PRECISION_LOWP float l10 = luma(t10);
+    COMPAT_PRECISION_LOWP float l11 = luma(t11);
+    COMPAT_PRECISION_LOWP float l13 = luma(t13);
+    COMPAT_PRECISION_LOWP float l14 = luma(t14);
+
+    Quad quads[5];
+    quads[0] = quad(vec4(l05, l06, l09, l10));
+    quads[1] = quad(vec4(l01, l02, l05, l06));
+    quads[2] = quad(vec4(l06, l07, l10, l11));
+    quads[3] = quad(vec4(l09, l10, l13, l14));
+    quads[4] = quad(vec4(l04, l05, l08, l09));
+
+    COMPAT_PRECISION_LOWP int pattern = findPattern(quads[0]);
+
+    COMPAT_PRECISION_LOWP ivec4 neighbors = ivec4(findPattern(quads[1]), findPattern(quads[2]), findPattern(quads[3]), findPattern(quads[4]));
+
+    COMPAT_PRECISION_LOWP vec4 edges = vec4(
+        hardEdgeWeight(pattern, neighbors.x, 1, 4, 3),
+        hardEdgeWeight(pattern, neighbors.y, 2, 3, 4),
+        hardEdgeWeight(pattern, neighbors.z, 1, 3, 4),
+        hardEdgeWeight(pattern, neighbors.w, 2, 4, 3)
+    );
+
+#if SOFT_EDGES_SHARPENING
+    COMPAT_PRECISION_LOWP vec4 softEdges = SOFT_EDGES_SHARPENING_AMOUNT * vec4(
+        softEdgeWeight(l04, l05, l06, l07),
+        softEdgeWeight(l02, l06, l10, l14),
+        softEdgeWeight(l08, l09, l10, l11),
+        softEdgeWeight(l01, l05, l09, l13)
+    );
+
+    edges = clamp(edges + softEdges, min(edges, softEdges), max(edges, softEdges));
+#endif
+
+    pattern = findPattern(quads);
+    pattern = pattern > 0 ? pattern : -pattern;
+
+    if (pattern == 3) {
+        edges = vec4(-edges.x, edges.w, -edges.z, edges.y);
+    }
+
+    COMPAT_PRECISION_LOWP vec4 result = vec4(
+        quickPackBools2(bvec2(pattern >= 3, pattern == 3)),
+        quickPackFloats2(edges.xy * 0.5 + vec2(0.5)),
+        quickPackFloats2(edges.zw * 0.5 + vec2(0.5)),
+        1.0
+    );
+
+    FragColor = result;
+}
+#endif

--- a/cut/shaders/cut2/cut2-pass1.glsl
+++ b/cut/shaders/cut2/cut2-pass1.glsl
@@ -1,0 +1,329 @@
+/*
+ * Cheap Upscaling Triangulation
+ *
+ * Copyright (c) Filippo Scognamiglio 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 screenCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 passCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    COMPAT_PRECISION_HIGHP vec2 coords = TexCoord.xy * 1.00001;
+    screenCoords = coords * TextureSize - vec2(0.5);
+    c05 = (screenCoords + vec2(+0.0, +0.0)) / TextureSize;
+    c06 = (screenCoords + vec2(+1.0, +0.0)) / TextureSize;
+    c09 = (screenCoords + vec2(+0.0, +1.0)) / TextureSize;
+    c10 = (screenCoords + vec2(+1.0, +1.0)) / TextureSize;
+    passCoords = c05;
+    gl_Position = MVPMatrix * VertexCoord;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#define EPSILON 0.02
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+uniform sampler2D PassPrev2Texture;
+uniform COMPAT_PRECISION vec2 PassPrev2TextureSize;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 screenCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 passCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float BLEND_MIN_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MAX_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MIN_SHARPNESS;
+uniform COMPAT_PRECISION float BLEND_MAX_SHARPNESS;
+uniform COMPAT_PRECISION float SOFT_EDGES_SHARPENING_AMOUNT;
+#else
+#define BLEND_MIN_CONTRAST_EDGE 0.0
+#define BLEND_MAX_CONTRAST_EDGE 0.5
+#define BLEND_MIN_SHARPNESS 0.0
+#define BLEND_MAX_SHARPNESS 0.7
+#define SOFT_EDGES_SHARPENING_AMOUNT 1.0
+#endif
+
+#define USE_DYNAMIC_BLEND 1
+#define STATIC_BLEND_SHARPNESS 0.0
+#define EDGE_USE_FAST_LUMA 0
+#define SOFT_EDGES_SHARPENING 1
+#define EDGE_MIN_VALUE 0.025
+
+COMPAT_PRECISION_LOWP float luma(COMPAT_PRECISION_LOWP vec3 v) {
+    return v.g;
+}
+
+struct Pixels {
+    COMPAT_PRECISION_LOWP vec3 p0;
+    COMPAT_PRECISION_LOWP vec3 p1;
+    COMPAT_PRECISION_LOWP vec3 p2;
+    COMPAT_PRECISION_LOWP vec3 p3;
+};
+
+struct ShapeWeights {
+    COMPAT_PRECISION_LOWP vec3 weights;
+    COMPAT_PRECISION_LOWP vec3 midPoints;
+};
+
+struct Pattern {
+    Pixels pixels;
+    COMPAT_PRECISION_LOWP vec3 weights;
+    COMPAT_PRECISION_LOWP vec3 midPoints;
+    COMPAT_PRECISION_LOWP vec3 baseSharpness;
+};
+
+struct Flags {
+    bool flip;
+    bool triangle;
+    COMPAT_PRECISION_LOWP vec4 edgeWeight;
+};
+
+COMPAT_PRECISION_LOWP vec2 quickUnpackFloats2(COMPAT_PRECISION_LOWP float value) {
+    COMPAT_PRECISION_LOWP vec2 result = vec2(0.0);
+    COMPAT_PRECISION_LOWP float current = value;
+
+    current *= 16.0;
+    result.x = floor(current);
+    current -= result.x;
+
+    current *= 16.0;
+    result.y = floor(current);
+    current -= result.y;
+
+    return result / 12.0;
+}
+
+bvec2 quickUnpackBools2(COMPAT_PRECISION_LOWP float value) {
+    COMPAT_PRECISION_LOWP vec2 result = vec2(0.0);
+    COMPAT_PRECISION_LOWP float current = value;
+
+    current *= 2.0;
+    result.x = floor(current);
+    current -= result.x;
+
+    current *= 2.0;
+    result.y = floor(current);
+    current -= result.y;
+
+    return greaterThan(result, vec2(0.5));
+}
+
+Flags parseFlags(COMPAT_PRECISION_LOWP vec3 flagsPixel) {
+    Flags flags;
+    flags.edgeWeight = clamp(
+        vec4(quickUnpackFloats2(flagsPixel.y + 0.001953125), quickUnpackFloats2(flagsPixel.z + 0.001953125)),
+        EPSILON,
+        1.0 - EPSILON
+    );
+    bvec2 boolFlags = quickUnpackBools2(flagsPixel.x + 0.125);
+    flags.triangle = boolFlags.x;
+    flags.flip = boolFlags.y;
+    return flags;
+}
+
+COMPAT_PRECISION_LOWP float linearStep(COMPAT_PRECISION_LOWP float edge0, COMPAT_PRECISION_LOWP float edge1, COMPAT_PRECISION_LOWP float t) {
+    return clamp((t - edge0) / (edge1 - edge0), 0.0, 1.0);
+}
+
+COMPAT_PRECISION_LOWP float sharpness(COMPAT_PRECISION_LOWP float l1, COMPAT_PRECISION_LOWP float l2) {
+#if USE_DYNAMIC_BLEND
+    COMPAT_PRECISION_LOWP float blendDiffInv = 1.0 / (BLEND_MAX_CONTRAST_EDGE - BLEND_MIN_CONTRAST_EDGE);
+    COMPAT_PRECISION_LOWP float lumaDiff = abs(l1 - l2);
+    COMPAT_PRECISION_LOWP float contrast = clamp((lumaDiff - BLEND_MIN_CONTRAST_EDGE) * blendDiffInv, 0.0, 1.0);
+    COMPAT_PRECISION_LOWP float result = mix(BLEND_MIN_SHARPNESS * 0.5, BLEND_MAX_SHARPNESS * 0.5, contrast);
+#else
+    COMPAT_PRECISION_LOWP float result = STATIC_BLEND_SHARPNESS * 0.5;
+#endif
+  return result;
+}
+
+COMPAT_PRECISION_LOWP float adjustMidpoint(COMPAT_PRECISION_LOWP float x, COMPAT_PRECISION_LOWP float midPoint) {
+    COMPAT_PRECISION_LOWP float result = 0.0;
+    result += clamp(x / midPoint, 0.0, 1.0);
+    result += clamp((x - midPoint) / (1.0 - midPoint), 0.0, 1.0);
+    return 0.5 * result;
+}
+
+COMPAT_PRECISION_LOWP vec3 blend(COMPAT_PRECISION_LOWP vec3 a, COMPAT_PRECISION_LOWP vec3 b, COMPAT_PRECISION_LOWP float t, COMPAT_PRECISION_LOWP float midPoint, COMPAT_PRECISION_LOWP float baseSharpness) {
+    COMPAT_PRECISION_LOWP float sharpness = baseSharpness * sharpness(luma(a), luma(b));
+    COMPAT_PRECISION_LOWP float nt = adjustMidpoint(t, midPoint);
+    nt = clamp((nt - sharpness) / (1.0 - 2.0 * sharpness), 0.0 , 1.0);
+    return mix(a, b, nt);
+}
+
+Pattern pattern(Pixels pixels, COMPAT_PRECISION_LOWP vec4 edgeWeights, bool triangle, COMPAT_PRECISION_LOWP vec2 pxCoords) {
+    Pattern result;
+
+    bool firstTriangle = triangle && pxCoords.x + pxCoords.y <= 1.0;
+    bool secondTriangle = triangle && !firstTriangle;
+
+    COMPAT_PRECISION_LOWP vec2 midPoints = vec2(0.0);
+
+    if (secondTriangle) {
+        pxCoords = vec2(1.0 - pxCoords.y, 1.0 - pxCoords.x);
+        pixels = Pixels(pixels.p3, pixels.p1, pixels.p2, pixels.p0);
+        edgeWeights = vec4(1.0) - edgeWeights.yxwz;
+    }
+
+    if (triangle) {
+        COMPAT_PRECISION_LOWP float coordsSum = pxCoords.x + pxCoords.y;
+        midPoints = vec2(
+        edgeWeights.x * edgeWeights.w * coordsSum / (edgeWeights.w * pxCoords.x + edgeWeights.x * pxCoords.y),
+        0.5 + 0.5 * clamp(-edgeWeights.x + edgeWeights.y - edgeWeights.z + edgeWeights.w, -1.0, 1.0)
+        );
+        pxCoords = vec2(coordsSum, pxCoords.y / coordsSum);
+    } else {
+        midPoints = vec2(
+        mix(edgeWeights.x, edgeWeights.z, pxCoords.y),
+        mix(edgeWeights.w, edgeWeights.y, pxCoords.x)
+        );
+    }
+
+    result.weights = pxCoords.xxy;
+    result.midPoints = midPoints.xxy;
+    result.baseSharpness = vec3(1.0, 1.0, float(!triangle));
+    result.pixels = Pixels(
+        pixels.p0,
+        pixels.p1,
+        triangle ? pixels.p0 : pixels.p2,
+        triangle ? pixels.p2 : pixels.p3
+    );
+
+    return result;
+}
+
+void main() {
+    COMPAT_PRECISION_LOWP vec3 t05 = COMPAT_TEXTURE(PassPrev2Texture, c05).rgb;
+    COMPAT_PRECISION_LOWP vec3 t06 = COMPAT_TEXTURE(PassPrev2Texture, c06).rgb;
+    COMPAT_PRECISION_LOWP vec3 t09 = COMPAT_TEXTURE(PassPrev2Texture, c09).rgb;
+    COMPAT_PRECISION_LOWP vec3 t10 = COMPAT_TEXTURE(PassPrev2Texture, c10).rgb;
+
+    COMPAT_PRECISION_LOWP vec3 flagsPixel = COMPAT_TEXTURE(Texture, passCoords).xyz;
+    Flags flags = parseFlags(flagsPixel);
+    Pixels pixels = Pixels(t05, t06, t09, t10);
+
+    COMPAT_PRECISION_LOWP vec2 pxCoords = fract(screenCoords);
+    COMPAT_PRECISION_LOWP vec4 edges = flags.edgeWeight;
+
+    if (flags.flip) {
+        pixels = Pixels(pixels.p1, pixels.p0, pixels.p3, pixels.p2);
+        pxCoords.x = 1.0 - pxCoords.x;
+    }
+
+    Pattern pattern = pattern(pixels, edges, flags.triangle, pxCoords);
+
+    COMPAT_PRECISION_LOWP vec3 final = blend(
+        blend(pattern.pixels.p0, pattern.pixels.p1, pattern.weights.x, pattern.midPoints.x, pattern.baseSharpness.x),
+        blend(pattern.pixels.p2, pattern.pixels.p3, pattern.weights.y, pattern.midPoints.y, pattern.baseSharpness.y),
+        pattern.weights.z,
+        pattern.midPoints.z,
+        pattern.baseSharpness.z
+    );
+
+    FragColor = vec4(final.rgb, 1.0);
+}
+#endif

--- a/cut/shaders/cut3/cut3-pass0.glsl
+++ b/cut/shaders/cut3/cut3-pass0.glsl
@@ -1,0 +1,355 @@
+/*
+ * Cheap Upscaling Triangulation
+ *
+ * Copyright (c) Filippo Scognamiglio 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma parameter BLEND_MIN_CONTRAST_EDGE "Min contrast edge strength" 0.0 0.0 1.0
+#pragma parameter BLEND_MAX_CONTRAST_EDGE "Max contrast edge strength" 0.5 0.0 1.0
+#pragma parameter BLEND_MIN_SHARPNESS "Min sharpness" 0.0 0.0 1.0
+#pragma parameter BLEND_MAX_SHARPNESS "Max sharpness" 0.7 0.0 1.0
+#pragma parameter SOFT_EDGES_SHARPENING_AMOUNT "Soft edges sharpening" 1.0 0.0 1.0
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c01;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c02;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c04;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c07;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c08;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c11;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c13;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c14;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    COMPAT_PRECISION_HIGHP vec2 coords = TexCoord.xy * 1.00001;
+    COMPAT_PRECISION_HIGHP vec2 screenCoords = coords * TextureSize - vec2(0.5);
+    c01 = (screenCoords + vec2(+0.0, -1.0)) / TextureSize;
+    c02 = (screenCoords + vec2(+1.0, -1.0)) / TextureSize;
+    c04 = (screenCoords + vec2(-1.0, +0.0)) / TextureSize;
+    c05 = (screenCoords + vec2(+0.0, +0.0)) / TextureSize;
+    c06 = (screenCoords + vec2(+1.0, +0.0)) / TextureSize;
+    c07 = (screenCoords + vec2(+2.0, +0.0)) / TextureSize;
+    c08 = (screenCoords + vec2(-1.0, +1.0)) / TextureSize;
+    c09 = (screenCoords + vec2(+0.0, +1.0)) / TextureSize;
+    c10 = (screenCoords + vec2(+1.0, +1.0)) / TextureSize;
+    c11 = (screenCoords + vec2(+2.0, +1.0)) / TextureSize;
+    c13 = (screenCoords + vec2(+0.0, +2.0)) / TextureSize;
+    c14 = (screenCoords + vec2(+1.0, +2.0)) / TextureSize;
+    gl_Position = MVPMatrix * VertexCoord;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#define EPSILON 0.02
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c01;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c02;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c04;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c07;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c08;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c11;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c13;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c14;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float BLEND_MIN_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MAX_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MIN_SHARPNESS;
+uniform COMPAT_PRECISION float BLEND_MAX_SHARPNESS;
+uniform COMPAT_PRECISION float SOFT_EDGES_SHARPENING_AMOUNT;
+#else
+#define BLEND_MIN_CONTRAST_EDGE 0.0
+#define BLEND_MAX_CONTRAST_EDGE 0.5
+#define BLEND_MIN_SHARPNESS 0.0
+#define BLEND_MAX_SHARPNESS 0.7
+#define SOFT_EDGES_SHARPENING_AMOUNT 1.0
+#endif
+
+#define USE_DYNAMIC_BLEND 1
+#define STATIC_BLEND_SHARPNESS 0.00
+#define EDGE_USE_FAST_LUMA 0
+#define EDGE_MIN_VALUE 0.025
+#define SOFT_EDGES_SHARPENING 1
+#define SEARCH_MIN_CONTRAST 0.5
+#define SEARCH_MAX_DISTANCE 8
+
+COMPAT_PRECISION_LOWP float maxOf(COMPAT_PRECISION_LOWP vec4 values) {
+    return max(max(values.x, values.y), max(values.z, values.w));
+}
+
+COMPAT_PRECISION_LOWP float minOf(COMPAT_PRECISION_LOWP vec4 values) {
+    return min(min(values.x, values.y), min(values.z, values.w));
+}
+
+COMPAT_PRECISION_LOWP float luma(COMPAT_PRECISION_LOWP vec3 v) {
+#if EDGE_USE_FAST_LUMA
+  COMPAT_PRECISION_LOWP float result = v.g;
+#else
+  COMPAT_PRECISION_LOWP float result = dot(v, vec3(0.299, 0.587, 0.114));
+#endif
+  return result;
+}
+
+COMPAT_PRECISION_LOWP float quickPackBools2(bvec2 values) {
+    return dot(vec2(values), vec2(0.5, 0.25));
+}
+
+COMPAT_PRECISION_LOWP float quickPackFloats2(COMPAT_PRECISION_LOWP vec2 values) {
+    return dot(floor(values * vec2(12.0) + vec2(0.5)), vec2(0.0625, 0.00390625));
+}
+
+struct Quad {
+    COMPAT_PRECISION_LOWP vec4 scores;
+    COMPAT_PRECISION_LOWP float localContrast;
+};
+
+Quad quad(COMPAT_PRECISION_LOWP vec4 values) {
+    COMPAT_PRECISION_LOWP vec4 edges = values.xyzx - values.ywwz;
+
+    Quad result;
+    result.scores = vec4(
+        abs(edges.x + edges.z),
+        abs(edges.w + edges.y),
+        max(abs(edges.x - edges.y), abs(edges.w - edges.z)),
+        max(abs(edges.x + edges.w), abs(edges.y + edges.z))
+    );
+    result.localContrast = maxOf(values) - minOf(values);
+    return result;
+}
+
+COMPAT_PRECISION_LOWP int computePattern(COMPAT_PRECISION_LOWP vec4 scores, COMPAT_PRECISION_LOWP vec4 neighborsScores) {
+    bool isDiagonal = max(scores.z, scores.w) > max(scores.x, scores.y);
+
+    scores += 0.25 * neighborsScores;
+
+    COMPAT_PRECISION_LOWP int result = 0;
+    if (!isDiagonal) {
+        if (scores.x > scores.y + EDGE_MIN_VALUE) {
+            result = 1;
+        } else if (scores.y > scores.x + EDGE_MIN_VALUE) {
+            result = 2;
+        }
+    } else {
+        if (scores.z > scores.w + EDGE_MIN_VALUE) {
+            result = 3;
+        } else if (scores.w > scores.z + EDGE_MIN_VALUE) {
+            result = 4;
+        }
+    }
+
+    return result;
+}
+
+COMPAT_PRECISION_LOWP int findPattern(Quad quad) {
+    return computePattern(quad.scores, vec4(0.0));
+}
+
+COMPAT_PRECISION_LOWP int findPattern(Quad quads[5]) {
+    COMPAT_PRECISION_LOWP vec4 scores = quads[0].scores;
+    COMPAT_PRECISION_LOWP vec4 adjustments = vec4(0.0);
+    adjustments += quads[1].scores;
+    adjustments += quads[2].scores;
+    adjustments += quads[3].scores;
+    adjustments += quads[4].scores;
+    return computePattern(scores, adjustments);
+}
+
+COMPAT_PRECISION_LOWP float softEdgeWeight(COMPAT_PRECISION_LOWP float a, COMPAT_PRECISION_LOWP float b, COMPAT_PRECISION_LOWP float c, COMPAT_PRECISION_LOWP float d) {
+    COMPAT_PRECISION_LOWP float result = 0.0;
+    result += clamp((abs(b - c) / (abs(a - c) + EPSILON)), 0.0, 1.0);
+    result -= clamp((abs(c - b) / (abs(b - d) + EPSILON)), 0.0, 1.0);
+    return clamp(2.0 * result, -1.0, 1.0);
+}
+
+void main() {
+    COMPAT_PRECISION_LOWP vec3 t01 = COMPAT_TEXTURE(Texture, c01).rgb;
+    COMPAT_PRECISION_LOWP vec3 t02 = COMPAT_TEXTURE(Texture, c02).rgb;
+    COMPAT_PRECISION_LOWP vec3 t04 = COMPAT_TEXTURE(Texture, c04).rgb;
+    COMPAT_PRECISION_LOWP vec3 t05 = COMPAT_TEXTURE(Texture, c05).rgb;
+    COMPAT_PRECISION_LOWP vec3 t06 = COMPAT_TEXTURE(Texture, c06).rgb;
+    COMPAT_PRECISION_LOWP vec3 t07 = COMPAT_TEXTURE(Texture, c07).rgb;
+    COMPAT_PRECISION_LOWP vec3 t08 = COMPAT_TEXTURE(Texture, c08).rgb;
+    COMPAT_PRECISION_LOWP vec3 t09 = COMPAT_TEXTURE(Texture, c09).rgb;
+    COMPAT_PRECISION_LOWP vec3 t10 = COMPAT_TEXTURE(Texture, c10).rgb;
+    COMPAT_PRECISION_LOWP vec3 t11 = COMPAT_TEXTURE(Texture, c11).rgb;
+    COMPAT_PRECISION_LOWP vec3 t13 = COMPAT_TEXTURE(Texture, c13).rgb;
+    COMPAT_PRECISION_LOWP vec3 t14 = COMPAT_TEXTURE(Texture, c14).rgb;
+
+    COMPAT_PRECISION_LOWP float l01 = luma(t01);
+    COMPAT_PRECISION_LOWP float l02 = luma(t02);
+    COMPAT_PRECISION_LOWP float l04 = luma(t04);
+    COMPAT_PRECISION_LOWP float l05 = luma(t05);
+    COMPAT_PRECISION_LOWP float l06 = luma(t06);
+    COMPAT_PRECISION_LOWP float l07 = luma(t07);
+    COMPAT_PRECISION_LOWP float l08 = luma(t08);
+    COMPAT_PRECISION_LOWP float l09 = luma(t09);
+    COMPAT_PRECISION_LOWP float l10 = luma(t10);
+    COMPAT_PRECISION_LOWP float l11 = luma(t11);
+    COMPAT_PRECISION_LOWP float l13 = luma(t13);
+    COMPAT_PRECISION_LOWP float l14 = luma(t14);
+
+    Quad quads[5];
+    quads[0] = quad(vec4(l05, l06, l09, l10));
+    quads[1] = quad(vec4(l01, l02, l05, l06));
+    quads[2] = quad(vec4(l06, l07, l10, l11));
+    quads[3] = quad(vec4(l09, l10, l13, l14));
+    quads[4] = quad(vec4(l04, l05, l08, l09));
+
+    COMPAT_PRECISION_LOWP int pattern = findPattern(quads);
+
+    COMPAT_PRECISION_LOWP vec4 neighborContrasts = max(
+        vec4(quads[0].localContrast),
+        vec4(quads[1].localContrast, quads[2].localContrast, quads[3].localContrast, quads[4].localContrast)
+    );
+
+    COMPAT_PRECISION_LOWP vec4 mainValues = vec4(l05, l06, l09, l10);
+    COMPAT_PRECISION_LOWP vec4 mainEdges = abs(mainValues.xyzx - mainValues.ywwz);
+    bvec4 neighborConnections = greaterThanEqual(mainEdges, SEARCH_MIN_CONTRAST * neighborContrasts);
+
+    COMPAT_PRECISION_LOWP ivec4 neighborPatterns = ivec4(
+        findPattern(quads[1]),
+        findPattern(quads[2]),
+        findPattern(quads[3]),
+        findPattern(quads[4])
+    );
+    neighborPatterns *= ivec4(neighborConnections);
+
+    bool vertical = any(equal(neighborPatterns.xz, ivec2(1)));
+    bool horizontal = any(equal(neighborPatterns.yw, ivec2(2)));
+    bool corner = vertical && horizontal;
+    bool opposite = any(equal(neighborPatterns, ivec4(pattern == 3 ? 4 : 3)));
+    bool isTriangle = pattern >= 3;
+
+    bool reject = (isTriangle && (opposite || corner)) || !any(neighborConnections);
+
+    COMPAT_PRECISION_LOWP vec4 result = vec4(0.0);
+
+#if SOFT_EDGES_SHARPENING
+    COMPAT_PRECISION_LOWP vec4 softEdges = vec4(
+        softEdgeWeight(l04, l05, l06, l07),
+        softEdgeWeight(l02, l06, l10, l14),
+        softEdgeWeight(l08, l09, l10, l11),
+        softEdgeWeight(l01, l05, l09, l13)
+    );
+
+    COMPAT_PRECISION_LOWP float softEdgesStrength = dot(abs(softEdges), vec4(1.0));
+    reject = reject || softEdgesStrength > 2.0;
+
+    result.y = quickPackFloats2(softEdges.xy * 0.5 + vec2(0.5));
+    result.z = quickPackFloats2(softEdges.zw * 0.5 + vec2(0.5));
+#endif
+
+    if (reject) {
+        pattern = -pattern;
+    }
+
+    result.x = float(pattern + 4) / 8.0;
+    FragColor = result;
+}
+
+#endif

--- a/cut/shaders/cut3/cut3-pass1.glsl
+++ b/cut/shaders/cut3/cut3-pass1.glsl
@@ -1,0 +1,311 @@
+/*
+ * Cheap Upscaling Triangulation
+ *
+ * Copyright (c) Filippo Scognamiglio 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 passCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 dc;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    COMPAT_PRECISION_HIGHP vec2 coords = TexCoord.xy * 1.00001;
+    COMPAT_PRECISION_HIGHP vec2 screenCoords = coords * TextureSize - vec2(0.5);
+    c05 = (screenCoords + vec2(+0.0, +0.0)) / TextureSize;
+    passCoords = c05;
+    dc = vec2(1.0) / TextureSize;
+    gl_Position = MVPMatrix * VertexCoord;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#define EPSILON 0.02
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+uniform sampler2D PassPrev2Texture;
+uniform COMPAT_PRECISION vec2 PassPrev2TextureSize;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 passCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 dc;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float BLEND_MIN_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MAX_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MIN_SHARPNESS;
+uniform COMPAT_PRECISION float BLEND_MAX_SHARPNESS;
+uniform COMPAT_PRECISION float SOFT_EDGES_SHARPENING_AMOUNT;
+#else
+#define BLEND_MIN_CONTRAST_EDGE 0.0
+#define BLEND_MAX_CONTRAST_EDGE 0.5
+#define BLEND_MIN_SHARPNESS 0.0
+#define BLEND_MAX_SHARPNESS 0.7
+#define SOFT_EDGES_SHARPENING_AMOUNT 1.0
+#endif
+
+#define USE_DYNAMIC_BLEND 1
+#define STATIC_BLEND_SHARPNESS 0.00
+#define EDGE_USE_FAST_LUMA 0
+#define EDGE_MIN_VALUE 0.025
+#define SOFT_EDGES_SHARPENING 1
+#define SEARCH_MIN_CONTRAST 0.5
+#define SEARCH_MAX_DISTANCE 8
+
+const COMPAT_PRECISION_LOWP float STEP = 0.5 / float(SEARCH_MAX_DISTANCE);
+const COMPAT_PRECISION_LOWP float HSTEP = (STEP * 0.5);
+
+COMPAT_PRECISION_LOWP float quickPackBools2(bvec2 values) {
+    return dot(vec2(values), vec2(0.5, 0.25));
+}
+
+COMPAT_PRECISION_LOWP float quickPackFloats2(COMPAT_PRECISION_LOWP vec2 values) {
+    return dot(floor(values * vec2(12.0) + vec2(0.5)), vec2(0.0625, 0.00390625));
+}
+
+COMPAT_PRECISION_LOWP vec2 quickUnpackFloats2(COMPAT_PRECISION_LOWP float value) {
+    COMPAT_PRECISION_LOWP vec2 result = vec2(0.0);
+    COMPAT_PRECISION_LOWP float current = value;
+
+    current *= 16.0;
+    result.x = floor(current);
+    current -= result.x;
+
+    current *= 16.0;
+    result.y = floor(current);
+    current -= result.y;
+
+    return result / 12.0;
+}
+
+bvec2 quickUnpackBools2(COMPAT_PRECISION_LOWP float value) {
+    COMPAT_PRECISION_LOWP vec2 result = vec2(0.0);
+    COMPAT_PRECISION_LOWP float current = value;
+
+    current *= 2.0;
+    result.x = floor(current);
+    current -= result.x;
+
+    current *= 2.0;
+    result.y = floor(current);
+    current -= result.y;
+
+    return greaterThan(result, vec2(0.5));
+}
+
+COMPAT_PRECISION_LOWP int fetchPattern(COMPAT_PRECISION_LOWP float value) {
+    return int(value * 8.0 + 0.5) - 4;
+}
+
+COMPAT_PRECISION_LOWP vec2 walk(
+    COMPAT_PRECISION_LOWP sampler2D previousPass,
+    COMPAT_PRECISION_HIGHP vec2 baseCoords,
+    COMPAT_PRECISION_HIGHP vec2 direction,
+    COMPAT_PRECISION_LOWP vec2 results,
+    COMPAT_PRECISION_LOWP int continuePattern
+) {
+    COMPAT_PRECISION_LOWP vec2 result = vec2(0.0, 0.0);
+    for (COMPAT_PRECISION_LOWP int i = 1; i <= SEARCH_MAX_DISTANCE; i++) {
+        COMPAT_PRECISION_HIGHP vec2 coords = baseCoords + direction * float(i);
+        COMPAT_PRECISION_LOWP int currentPattern = fetchPattern(COMPAT_TEXTURE(previousPass, coords).x);
+
+        if (currentPattern == 3) {
+            result.y = results.x;
+        } else if (currentPattern == 4) {
+            result.y = results.y;
+        }
+
+        if (currentPattern == 3 || currentPattern == 4) {
+            result.x += HSTEP;
+        } else if (currentPattern == continuePattern) {
+            result.x += STEP;
+        }
+
+        if (currentPattern != continuePattern) { break; }
+    }
+    return result;
+}
+
+COMPAT_PRECISION_LOWP float blendWeights(COMPAT_PRECISION_LOWP vec2 d1, COMPAT_PRECISION_LOWP vec2 d2) {
+    const float MAX_DOUBLE_DISTANCE = float(SEARCH_MAX_DISTANCE) * STEP;
+    const float MAX_DISTANCE = STEP * float(SEARCH_MAX_DISTANCE / 2) + HSTEP;
+
+    COMPAT_PRECISION_LOWP float result = 0.0;
+
+    COMPAT_PRECISION_LOWP float totalDistance = d1.x + d2.x;
+    COMPAT_PRECISION_LOWP float d1Ratio = d1.x / totalDistance;
+
+    if (totalDistance <= EPSILON) {
+        result = 0.0;
+    } else if (totalDistance <= MAX_DOUBLE_DISTANCE) {
+        result = (d1.x < d2.x) ? mix(d1.y, 0.0, 2.0 * d1Ratio) : mix(0.0, d2.y, (d1Ratio - 0.5) * 2.0);
+    } else if (d1.x <= MAX_DISTANCE) {
+        result = mix(d1.y, 0.0, d1.x / MAX_DISTANCE);
+    } else if (d2.x <= MAX_DISTANCE) {
+        result = mix(d2.y, 0.0, d2.x / MAX_DISTANCE);
+    }
+
+    return result;
+}
+
+void main() {
+    COMPAT_PRECISION_LOWP vec4 previousPassPixel = COMPAT_TEXTURE(Texture, passCoords);
+    COMPAT_PRECISION_LOWP int pattern = fetchPattern(previousPassPixel.x);
+
+    COMPAT_PRECISION_LOWP vec2 resultN = vec2(0.0, 0.0);
+    COMPAT_PRECISION_LOWP vec2 resultS = vec2(0.0, 0.0);
+    COMPAT_PRECISION_LOWP vec2 resultW = vec2(0.0, 0.0);
+    COMPAT_PRECISION_LOWP vec2 resultE = vec2(0.0, 0.0);
+
+    if (pattern == 1 || pattern == 3 || pattern == 4) {
+        resultN = walk(Texture, passCoords, vec2(0.0, -dc.y), vec2(-1.0, +1.0), 1);
+        resultS = walk(Texture, passCoords, vec2(0.0, +dc.y), vec2(+1.0, -1.0), 1);
+    }
+    if (pattern == 2 || pattern == 3 || pattern == 4) {
+        resultW = walk(Texture, passCoords, vec2(-dc.x, 0.0), vec2(-1.0, +1.0), 2);
+        resultE = walk(Texture, passCoords, vec2(+dc.x, 0.0), vec2(+1.0, -1.0), 2);
+    }
+    COMPAT_PRECISION_LOWP vec4 edgesWeights[4];
+
+    if (pattern == 1) {
+        edgesWeights[0] = vec4(resultN, resultS + vec2(STEP, 0.0));
+        edgesWeights[2] = vec4(resultN + vec2(STEP, 0.0), resultS);
+    } else if (pattern == 2) {
+        edgesWeights[3] = vec4(resultW, resultE + vec2(STEP, 0.0));
+        edgesWeights[1] = vec4(resultW + vec2(STEP, 0.0), resultE);
+    } else if (pattern == 3) {
+        edgesWeights[0] = vec4(resultN, vec2(HSTEP, 1.0));
+        edgesWeights[2] = vec4(vec2(HSTEP, -1.0), resultS);
+        edgesWeights[3] = vec4(resultW, vec2(HSTEP, 1.0));
+        edgesWeights[1] = vec4(vec2(HSTEP, -1.0), resultE);
+    } else if (pattern == 4) {
+        edgesWeights[0] = vec4(resultN, vec2(HSTEP, -1.0));
+        edgesWeights[2] = vec4(vec2(HSTEP, 1.0), resultS);
+        edgesWeights[3] = vec4(resultW, vec2(HSTEP, -1.0));
+        edgesWeights[1] = vec4(vec2(HSTEP, 1.0), resultE);
+    }
+    COMPAT_PRECISION_LOWP vec4 edges = vec4(
+        blendWeights(edgesWeights[0].xy, edgesWeights[0].zw),
+        blendWeights(edgesWeights[1].xy, edgesWeights[1].zw),
+        blendWeights(edgesWeights[2].xy, edgesWeights[2].zw),
+        blendWeights(edgesWeights[3].xy, edgesWeights[3].zw)
+    );
+
+#if SOFT_EDGES_SHARPENING
+    COMPAT_PRECISION_LOWP vec4 softEdges = 2.0 * SOFT_EDGES_SHARPENING_AMOUNT * vec4(
+        quickUnpackFloats2(previousPassPixel.y + 0.001953125) - vec2(0.5),
+        quickUnpackFloats2(previousPassPixel.z + 0.001953125) - vec2(0.5)
+    );
+
+    edges = clamp(edges + softEdges, min(edges, softEdges), max(edges, softEdges));
+#endif
+
+    COMPAT_PRECISION_LOWP int originalPattern = pattern >= 0 ? pattern : -pattern;
+    if (originalPattern == 3) {
+        edges = vec4(-edges.x, edges.w, -edges.z, edges.y);
+    }
+
+    FragColor = vec4(
+        quickPackBools2(bvec2(originalPattern >= 3, originalPattern == 3)),
+        quickPackFloats2(edges.xy * 0.5 + vec2(0.5)),
+        quickPackFloats2(edges.zw * 0.5 + vec2(0.5)),
+        1.0
+    );
+}
+
+#endif

--- a/cut/shaders/cut3/cut3-pass2.glsl
+++ b/cut/shaders/cut3/cut3-pass2.glsl
@@ -1,0 +1,331 @@
+/*
+ * Cheap Upscaling Triangulation
+ *
+ * Copyright (c) Filippo Scognamiglio 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 screenCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 passCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    COMPAT_PRECISION_HIGHP vec2 coords = TexCoord.xy * 1.00001;
+    screenCoords = coords * TextureSize - vec2(0.5);
+    c05 = (screenCoords + vec2(+0.0, +0.0)) / TextureSize;
+    c06 = (screenCoords + vec2(+1.0, +0.0)) / TextureSize;
+    c09 = (screenCoords + vec2(+0.0, +1.0)) / TextureSize;
+    c10 = (screenCoords + vec2(+1.0, +1.0)) / TextureSize;
+    passCoords = c05;
+    gl_Position = MVPMatrix * VertexCoord;
+}
+
+#elif defined(FRAGMENT)
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION_HIGHP highp
+#else
+#define COMPAT_PRECISION_HIGHP mediump
+#endif
+#define COMPAT_PRECISION_MEDIUMP mediump
+#define COMPAT_PRECISION_LOWP lowp
+#else
+#define COMPAT_PRECISION_HIGHP
+#define COMPAT_PRECISION_MEDIUMP
+#define COMPAT_PRECISION_LOWP
+#endif
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out COMPAT_PRECISION vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#define EPSILON 0.02
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+uniform sampler2D PassPrev3Texture;
+uniform COMPAT_PRECISION vec2 PassPrev3TextureSize;
+
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 screenCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 passCoords;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c05;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c06;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c09;
+COMPAT_VARYING COMPAT_PRECISION_HIGHP vec2 c10;
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float BLEND_MIN_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MAX_CONTRAST_EDGE;
+uniform COMPAT_PRECISION float BLEND_MIN_SHARPNESS;
+uniform COMPAT_PRECISION float BLEND_MAX_SHARPNESS;
+uniform COMPAT_PRECISION float SOFT_EDGES_SHARPENING_AMOUNT;
+#else
+#define BLEND_MIN_CONTRAST_EDGE 0.0
+#define BLEND_MAX_CONTRAST_EDGE 0.5
+#define BLEND_MIN_SHARPNESS 0.0
+#define BLEND_MAX_SHARPNESS 0.7
+#define SOFT_EDGES_SHARPENING_AMOUNT 1.0
+#endif
+
+#define USE_DYNAMIC_BLEND 1
+#define STATIC_BLEND_SHARPNESS 0.00
+#define EDGE_USE_FAST_LUMA 0
+#define EDGE_MIN_VALUE 0.025
+#define SOFT_EDGES_SHARPENING 1
+#define SEARCH_MIN_CONTRAST 0.5
+#define SEARCH_MAX_DISTANCE 8
+
+COMPAT_PRECISION_LOWP float luma(COMPAT_PRECISION_LOWP vec3 v) {
+    return v.g;
+}
+
+struct Pixels {
+    COMPAT_PRECISION_LOWP vec3 p0;
+    COMPAT_PRECISION_LOWP vec3 p1;
+    COMPAT_PRECISION_LOWP vec3 p2;
+    COMPAT_PRECISION_LOWP vec3 p3;
+};
+
+struct ShapeWeights {
+    COMPAT_PRECISION_LOWP vec3 weights;
+    COMPAT_PRECISION_LOWP vec3 midPoints;
+};
+
+struct Pattern {
+    Pixels pixels;
+    COMPAT_PRECISION_LOWP vec3 weights;
+    COMPAT_PRECISION_LOWP vec3 midPoints;
+    COMPAT_PRECISION_LOWP vec3 baseSharpness;
+};
+
+struct Flags {
+    bool flip;
+    bool triangle;
+    COMPAT_PRECISION_LOWP vec4 edgeWeight;
+};
+
+COMPAT_PRECISION_LOWP vec2 quickUnpackFloats2(COMPAT_PRECISION_LOWP float value) {
+    COMPAT_PRECISION_LOWP vec2 result = vec2(0.0);
+    COMPAT_PRECISION_LOWP float current = value;
+
+    current *= 16.0;
+    result.x = floor(current);
+    current -= result.x;
+
+    current *= 16.0;
+    result.y = floor(current);
+    current -= result.y;
+
+    return result / 12.0;
+}
+
+bvec2 quickUnpackBools2(COMPAT_PRECISION_LOWP float value) {
+    COMPAT_PRECISION_LOWP vec2 result = vec2(0.0);
+    COMPAT_PRECISION_LOWP float current = value;
+
+    current *= 2.0;
+    result.x = floor(current);
+    current -= result.x;
+
+    current *= 2.0;
+    result.y = floor(current);
+    current -= result.y;
+
+    return greaterThan(result, vec2(0.5));
+}
+
+Flags parseFlags(COMPAT_PRECISION_LOWP vec3 flagsPixel) {
+    Flags flags;
+    flags.edgeWeight = clamp(
+        vec4(quickUnpackFloats2(flagsPixel.y + 0.001953125), quickUnpackFloats2(flagsPixel.z + 0.001953125)),
+        EPSILON,
+        1.0 - EPSILON
+    );
+    bvec2 boolFlags = quickUnpackBools2(flagsPixel.x + 0.125);
+    flags.triangle = boolFlags.x;
+    flags.flip = boolFlags.y;
+    return flags;
+}
+
+COMPAT_PRECISION_LOWP float linearStep(COMPAT_PRECISION_LOWP float edge0, COMPAT_PRECISION_LOWP float edge1, COMPAT_PRECISION_LOWP float t) {
+    return clamp((t - edge0) / (edge1 - edge0), 0.0, 1.0);
+}
+
+COMPAT_PRECISION_LOWP float sharpness(COMPAT_PRECISION_LOWP float l1, COMPAT_PRECISION_LOWP float l2) {
+#if USE_DYNAMIC_BLEND
+    COMPAT_PRECISION_LOWP float blendDiffInv = 1.0 / (BLEND_MAX_CONTRAST_EDGE - BLEND_MIN_CONTRAST_EDGE);
+    COMPAT_PRECISION_LOWP float lumaDiff = abs(l1 - l2);
+    COMPAT_PRECISION_LOWP float contrast = clamp((lumaDiff - BLEND_MIN_CONTRAST_EDGE) * blendDiffInv, 0.0, 1.0);
+    COMPAT_PRECISION_LOWP float result = mix(BLEND_MIN_SHARPNESS * 0.5, BLEND_MAX_SHARPNESS * 0.5, contrast);
+#else
+    COMPAT_PRECISION_LOWP float result = STATIC_BLEND_SHARPNESS * 0.5;
+#endif
+  return result;
+}
+
+COMPAT_PRECISION_LOWP float adjustMidpoint(COMPAT_PRECISION_LOWP float x, COMPAT_PRECISION_LOWP float midPoint) {
+    COMPAT_PRECISION_LOWP float result = 0.0;
+    result += clamp(x / midPoint, 0.0, 1.0);
+    result += clamp((x - midPoint) / (1.0 - midPoint), 0.0, 1.0);
+    return 0.5 * result;
+}
+
+COMPAT_PRECISION_LOWP vec3 blend(COMPAT_PRECISION_LOWP vec3 a, COMPAT_PRECISION_LOWP vec3 b, COMPAT_PRECISION_LOWP float t, COMPAT_PRECISION_LOWP float midPoint, COMPAT_PRECISION_LOWP float baseSharpness) {
+    COMPAT_PRECISION_LOWP float sharpness = baseSharpness * sharpness(luma(a), luma(b));
+    COMPAT_PRECISION_LOWP float nt = adjustMidpoint(t, midPoint);
+    nt = clamp((nt - sharpness) / (1.0 - 2.0 * sharpness), 0.0 , 1.0);
+    return mix(a, b, nt);
+}
+
+Pattern pattern(Pixels pixels, COMPAT_PRECISION_LOWP vec4 edgeWeights, bool triangle, COMPAT_PRECISION_LOWP vec2 pxCoords) {
+    Pattern result;
+
+    bool firstTriangle = triangle && pxCoords.x + pxCoords.y <= 1.0;
+    bool secondTriangle = triangle && !firstTriangle;
+
+    COMPAT_PRECISION_LOWP vec2 midPoints = vec2(0.0);
+
+    if (secondTriangle) {
+        pxCoords = vec2(1.0 - pxCoords.y, 1.0 - pxCoords.x);
+        pixels = Pixels(pixels.p3, pixels.p1, pixels.p2, pixels.p0);
+        edgeWeights = vec4(1.0) - edgeWeights.yxwz;
+    }
+
+    if (triangle) {
+        COMPAT_PRECISION_LOWP float coordsSum = pxCoords.x + pxCoords.y;
+        midPoints = vec2(
+            edgeWeights.x * edgeWeights.w * coordsSum / (edgeWeights.w * pxCoords.x + edgeWeights.x * pxCoords.y),
+            0.5 + 0.5 * clamp(-edgeWeights.x + edgeWeights.y - edgeWeights.z + edgeWeights.w, -1.0, 1.0)
+        );
+        pxCoords = vec2(coordsSum, pxCoords.y / coordsSum);
+    } else {
+        midPoints = vec2(
+            mix(edgeWeights.x, edgeWeights.z, pxCoords.y),
+            mix(edgeWeights.w, edgeWeights.y, pxCoords.x)
+        );
+    }
+
+    result.weights = pxCoords.xxy;
+    result.midPoints = midPoints.xxy;
+    result.baseSharpness = vec3(1.0, 1.0, float(!triangle));
+    result.pixels = Pixels(
+        pixels.p0,
+        pixels.p1,
+        triangle ? pixels.p0 : pixels.p2,
+        triangle ? pixels.p2 : pixels.p3
+    );
+
+    return result;
+}
+
+void main() {
+    COMPAT_PRECISION_LOWP vec3 t05 = COMPAT_TEXTURE(PassPrev3Texture, c05).rgb;
+    COMPAT_PRECISION_LOWP vec3 t06 = COMPAT_TEXTURE(PassPrev3Texture, c06).rgb;
+    COMPAT_PRECISION_LOWP vec3 t09 = COMPAT_TEXTURE(PassPrev3Texture, c09).rgb;
+    COMPAT_PRECISION_LOWP vec3 t10 = COMPAT_TEXTURE(PassPrev3Texture, c10).rgb;
+
+    COMPAT_PRECISION_LOWP vec3 flagsPixel = COMPAT_TEXTURE(Texture, passCoords).xyz;
+    Flags flags = parseFlags(flagsPixel);
+    Pixels pixels = Pixels(t05, t06, t09, t10);
+
+    COMPAT_PRECISION_LOWP vec2 pxCoords = fract(screenCoords);
+    COMPAT_PRECISION_LOWP vec4 edges = flags.edgeWeight;
+
+    if (flags.flip) {
+        pixels = Pixels(pixels.p1, pixels.p0, pixels.p3, pixels.p2);
+        pxCoords.x = 1.0 - pxCoords.x;
+    }
+
+    Pattern pattern = pattern(pixels, edges, flags.triangle, pxCoords);
+
+    COMPAT_PRECISION_LOWP vec3 final = blend(
+        blend(pattern.pixels.p0, pattern.pixels.p1, pattern.weights.x, pattern.midPoints.x, pattern.baseSharpness.x),
+        blend(pattern.pixels.p2, pattern.pixels.p3, pattern.weights.y, pattern.midPoints.y, pattern.baseSharpness.y),
+        pattern.weights.z,
+        pattern.midPoints.z,
+        pattern.baseSharpness.z
+    );
+
+    FragColor = vec4(final.rgb, 1.0);
+}
+#endif


### PR DESCRIPTION
Hi! I've been working on porting CUT to libretro, starting with the glsl-shaders.

These are basically lightweight upscaling algorithms designed to support a wide variety of games, from 8bit up until more modern ones with antialiasing.

The different versions have tradeoffs between performances and quality, with CUT3 being the best looking and CUT1 the fastest (although all of them run at 60Hz even on low end hardware such as the nvidia shield).

You can check out the original source code with a bit more details [here](https://github.com/Swordfish90/cheap-upscaling-triangulation) and see them in action on a bunch of different games [here](https://swordfish90.github.io/cheap-upscaling-triangulation/).

Feel free to let me know if you'd like to change anything on the PR, and don't hesitate to tag me if any issues come up!