### PR TITLE
Adds fakelottes-ntsc-composite and fakelottes-ntsc-svideo

### DIFF
--- a/presets/fakelottes-ntsc-composite.glslp
+++ b/presets/fakelottes-ntsc-composite.glslp
@@ -1,0 +1,18 @@
+shaders = 3
+
+shader0 = ../ntsc/shaders/ntsc-adaptive/ntsc-pass1.glsl
+scale_type0 = source
+scale_x0 = 4.0
+filter_linear0 = false
+scale_y0 = 1.0
+float_framebuffer0 = true
+
+shader1 = ../ntsc/shaders/ntsc-adaptive/ntsc-pass2.glsl
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 1.0
+filter_linear1 = false
+wrap_mode1 = mirrored_repeat
+
+shader2 = ../crt/shaders/fakelottes.glsl
+filter_linear2 = true

--- a/presets/fakelottes-ntsc-svideo.glslp
+++ b/presets/fakelottes-ntsc-svideo.glslp
@@ -1,0 +1,20 @@
+shaders = 3
+
+shader0 = ../ntsc/shaders/ntsc-adaptive/ntsc-pass1.glsl
+scale_type0 = source
+scale_x0 = 4.0
+filter_linear0 = false
+scale_y0 = 1.0
+float_framebuffer0 = true
+
+shader1 = ../ntsc/shaders/ntsc-adaptive/ntsc-pass2.glsl
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 1.0
+filter_linear1 = false
+wrap_mode1 = mirrored_repeat
+
+shader2 = ../crt/shaders/fakelottes.glsl
+filter_linear2 = true
+
+quality = "0.000000"


### PR DESCRIPTION
Same as https://github.com/libretro/slang-shaders/pull/715, this adds the fakelottes-ntsc-composite and fakelottes-ntsc-svideo presets, which basically mixes the crt/fakelottes.glslp with ntsc/ntsc-adaptive.glslp presets. The fakelottes-ntsc-svideo variant just disables composite video artifacts.

Since here, unlike the slang variant, we don't have /presets/crt-plus-signal, I'm adding it directly to /presets.