### PR TITLE
Fix scalefx on GLES2

### DIFF
--- a/scalefx/shaders/scalefx-pass0.glsl
+++ b/scalefx/shaders/scalefx-pass0.glsl
@@ -1,5 +1,3 @@
-#version 130
-
 /*
 	ScaleFX - Pass 0
 	by Sp00kyFox, 2017-03-01

--- a/scalefx/shaders/scalefx-pass1.glsl
+++ b/scalefx/shaders/scalefx-pass1.glsl
@@ -1,5 +1,3 @@
-#version 130
-
 /*
 	ScaleFX - Pass 1
 	by Sp00kyFox, 2017-03-01

--- a/scalefx/shaders/scalefx-pass2.glsl
+++ b/scalefx/shaders/scalefx-pass2.glsl
@@ -1,5 +1,3 @@
-#version 130
-
 /*
 	ScaleFX - Pass 2
 	by Sp00kyFox, 2017-03-01

--- a/scalefx/shaders/scalefx-pass3.glsl
+++ b/scalefx/shaders/scalefx-pass3.glsl
@@ -1,5 +1,3 @@
-#version 130
-
 /*
 	ScaleFX - Pass 3
 	by Sp00kyFox, 2017-03-01

--- a/scalefx/shaders/scalefx-pass4.glsl
+++ b/scalefx/shaders/scalefx-pass4.glsl
@@ -1,5 +1,3 @@
-#version 130
-
 /*
 	ScaleFX - Pass 4
 	by Sp00kyFox, 2017-03-01


### PR DESCRIPTION
This removes the unnecessary `#version 130` directive, enabling it to work on GLES2. See also: https://github.com/libretro/RetroArch/blob/c31727344a37aa48c02fbaf853470aed344009ae/gfx/drivers_shader/shader_glsl.c#L379