### PR TITLE
build: Enable building cross-platform; don't install git history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ all:
 
 install:
 	mkdir -p $(DESTDIR)$(INSTALLDIR)
-	cp -ar -t $(DESTDIR)$(INSTALLDIR) *
-	rm -f $(DESTDIR)$(INSTALLDIR)/Makefile \
-		$(DESTDIR)$(INSTALLDIR)/configure
+	cp -r ./. $(DESTDIR)$(INSTALLDIR)
+	rm -f $(DESTDIR)$(INSTALLDIR)/Makefile
+	rm -f $(DESTDIR)$(INSTALLDIR)/configure
+	rm -f $(DESTDIR)$(INSTALLDIR)/.gitlab-ci.yml
+	rm -rf $(DESTDIR)$(INSTALLDIR)/.git
 
 test-install: all
 	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
This changes the `cp` operation to work on more platforms/environments, where the `-t` option is not available. Additionally remove the `.git` and `.gitlab-ci.yml` files after installation.

This is a copy of the work from @jcm93 with my followup correction in the slang-shader repository:
https://github.com/libretro/slang-shaders/pull/647/changes/9c5c712e154ecfe1f1d18f46a7e15157a67375e0
https://github.com/libretro/slang-shaders/commit/85955341f831aafd2151cfae304c59ad7b7a2c23