### PR TITLE
stop forcing mediump on GLES highp capable devices

### DIFF
--- a/crt/shaders/crt-pi.glsl
+++ b/crt/shaders/crt-pi.glsl
@@ -48,8 +48,16 @@ MASK_TYPE defines what, if any, shadow mask to use. MASK_BRIGHTNESS defines how 
 
 
 #ifdef GL_ES
-#define COMPAT_PRECISION mediump
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else 
+#define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif

--- a/crt/shaders/zfast_crt.glsl
+++ b/crt/shaders/zfast_crt.glsl
@@ -114,7 +114,11 @@ precision highp float;
 #else
 precision mediump float;
 #endif
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else 
 #define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif

--- a/crt/shaders/zfast_crt_geo.glsl
+++ b/crt/shaders/zfast_crt_geo.glsl
@@ -97,7 +97,11 @@ precision highp float;
 #else
 precision mediump float;
 #endif
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else 
 #define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif

--- a/crt/shaders/zfast_crt_geo_svideo.glsl
+++ b/crt/shaders/zfast_crt_geo_svideo.glsl
@@ -94,7 +94,11 @@ precision highp float;
 #else
 precision mediump float;
 #endif
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else 
 #define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif

--- a/crt/shaders/zfast_crt_nogeo.glsl
+++ b/crt/shaders/zfast_crt_nogeo.glsl
@@ -92,7 +92,11 @@ precision highp float;
 #else
 precision mediump float;
 #endif
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else 
 #define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif

--- a/crt/shaders/zfast_crt_nogeo_svideo.glsl
+++ b/crt/shaders/zfast_crt_nogeo_svideo.glsl
@@ -93,7 +93,11 @@ precision highp float;
 #else
 precision mediump float;
 #endif
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else 
 #define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif


### PR DESCRIPTION
This will fix scanlines on GLES highp capable devices. Now shader is perfectly 1:1 on s650 GLES phone vs my PC. 
Before with forced mediump = garbled scanlines.