### PR TITLE
avoid vertex/fragment precision mismatch

### DIFF
--- a/crt/shaders/zfast_crt.glsl
+++ b/crt/shaders/zfast_crt.glsl
@@ -52,7 +52,11 @@ Notes:  This shader does scaling with a weighted linear filter for adjustable
 #endif
 
 #ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else
 #define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif

--- a/crt/shaders/zfast_crt_nogeo.glsl
+++ b/crt/shaders/zfast_crt_nogeo.glsl
@@ -43,7 +43,11 @@ Dogway: This is the same as zfast_crt_geo but without the screen curvature for e
 #endif
 
 #ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+#define COMPAT_PRECISION highp
+#else
 #define COMPAT_PRECISION mediump
+#endif
 #else
 #define COMPAT_PRECISION
 #endif


### PR DESCRIPTION
in zfast-crt and zfast-crt-nogeo shaders. Closes #566 