### PR TITLE
xbr: initialize f4 in xbr-lv2

### DIFF
--- a/xbr/shaders/xbr-lv2.glsl
+++ b/xbr/shaders/xbr-lv2.glsl
@@ -288,6 +288,7 @@ void main()
 		i5 = mul( mat4x3(I5, C4, A1, G0), y_weight * Y );
 		h5 = mul( mat4x3(H5, F4, B1, D0), y_weight * Y );
 	}
+    f4 = h5.yzwx;
 
     // These inequations define the line below which interpolation occurs.
     fx   = (Ao*fp.y+Bo*fp.x); 


### PR DESCRIPTION
`xbr-lv2.glsl` declares `f4` alongside `i4`, `i5` and `h5`, but the small-details branches only initialize the latter three. `f4` is then read by the corner-detection and weighted-distance calculations.

Initialize `f4` from the branch-selected `h5` value using the same `h5.yzwx` swizzle as `xbr-lv2-noblend.glsl` and `xbr-lv3.glsl`.

This avoids using an undefined value without otherwise changing the filter.

Found downstream: https://github.com/kodi-game/game.shader.presets/pull/33